### PR TITLE
Show avatars and online status in forum posts

### DIFF
--- a/core/site/forum.php
+++ b/core/site/forum.php
@@ -1,0 +1,48 @@
+<?php
+require_once __DIR__ . '/user.php';
+
+/**
+ * Render a forum post with user avatar and online badge.
+ *
+ * Expected structure of $post:
+ * - 'author' => user id of the post author
+ * - 'text'   => post body
+ * - 'date'   => timestamp or formatted string
+ */
+function renderForumPost(array $post)
+{
+    $user = fetchUserInfo($post['author']);
+    if (!$user) {
+        return;
+    }
+
+    $username = htmlspecialchars($user['username']);
+    $profileLink = '/profile.php?id=' . intval($user['id']);
+    $avatarPath = 'media/pfp/' . $user['pfp'];
+    $avatarPath = htmlspecialchars($avatarPath);
+
+    // Determine if the user is currently online (active within last 5 minutes)
+    $badge = '';
+    if (!empty($user['lastactive'])) {
+        $lastActive = strtotime($user['lastactive']);
+        if ($lastActive !== false && (time() - $lastActive) <= 300) {
+            $badge = '<img class="online-badge" src="static/img/online_now.gif" alt="Online Now" loading="lazy">';
+        }
+    }
+
+    $body = nl2br(htmlspecialchars($post['text']));
+
+    echo "<div class='forum-post'>";
+    echo "  <div class='avatar-wrapper'>";
+    echo "    <a href='{$profileLink}'><img class='avatar' src='{$avatarPath}' alt='{$username}\'s avatar' loading='lazy'></a>";
+    if ($badge) {
+        echo $badge;
+    }
+    echo "  </div>";
+    echo "  <div class='post-body'>";
+    echo "    <a class='username' href='{$profileLink}'>{$username}</a>";
+    echo "    <p>{$body}</p>";
+    echo "  </div>";
+    echo "</div>";
+}
+?>

--- a/public/static/css/forum.css
+++ b/public/static/css/forum.css
@@ -17,3 +17,20 @@ body {
     background-image: linear-gradient(to bottom, var(--logo-blue), var(--light-orange));
     color: #fff;
 }
+
+.forum-post .avatar {
+    width: 50px;
+    height: 50px;
+    object-fit: cover;
+}
+
+.forum-post .avatar-wrapper {
+    position: relative;
+    display: inline-block;
+}
+
+.forum-post .online-badge {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+}


### PR DESCRIPTION
## Summary
- Render forum posts with user avatars and optional online-now badge
- Style forum avatars at 50px square with overlay positioning
- Remove placeholder `online_now.gif` asset

## Testing
- `php -l core/site/forum.php`


------
https://chatgpt.com/codex/tasks/task_e_6894c3809a308321a09a1cbd82f04daa