### PR TITLE
Add forum permission helper and checks

### DIFF
--- a/core/forum.php
+++ b/core/forum.php
@@ -1,0 +1,40 @@
+<?php
+require_once(__DIR__.'/helper.php'); // ensure login_check available
+
+function forum_user_role() {
+    // Determine the current user's role
+    if (!isset($_SESSION['userId'])) {
+        return 'guest';
+    }
+    if (defined('ADMIN_USER') && $_SESSION['userId'] == ADMIN_USER) {
+        return 'admin';
+    }
+    return 'member';
+}
+
+function forum_fetch_permissions($forum_id) {
+    global $conn;
+    $role = forum_user_role();
+    $stmt = $conn->prepare('SELECT can_view, can_post, can_moderate FROM forum_permissions WHERE forum_id = :fid AND role = :role');
+    $stmt->execute([':fid' => $forum_id, ':role' => $role]);
+    $perm = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$perm) {
+        return ['can_view' => 0, 'can_post' => 0, 'can_moderate' => 0];
+    }
+    return $perm;
+}
+
+function forum_require_permission($forum_id, $flag) {
+    $perms = forum_fetch_permissions($forum_id);
+    $allowed = isset($perms[$flag]) ? (int)$perms[$flag] : 0;
+    if (!$allowed) {
+        if (!isset($_SESSION['user'])) {
+            login_check(); // redirects to login
+        }
+        header('HTTP/1.1 403 Forbidden');
+        echo 'Forbidden';
+        exit;
+    }
+    return true;
+}
+?>

--- a/public/forum.php
+++ b/public/forum.php
@@ -1,11 +1,10 @@
 <?php
 require("../core/conn.php");
 require_once("../core/settings.php");
+require_once("../core/forum.php");
 
-if (!isset($_SESSION['user'])) {
-    header("Location: login.php");
-    exit;
-}
+$forumId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+forum_require_permission($forumId, 'can_view');
 
 $pageCSS = "static/css/forum.css";
 

--- a/public/forum/index.php
+++ b/public/forum/index.php
@@ -1,10 +1,19 @@
 <?php
 require("../../core/conn.php");
 require_once("../../core/settings.php");
+require_once("../../core/forum.php");
 
-if (!isset($_SESSION['user'])) {
-    header("Location: ../login.php");
-    exit;
+$forumId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+forum_require_permission($forumId, 'can_view');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    forum_require_permission($forumId, 'can_post');
+    // process post submission here
+}
+
+if (isset($_GET['moderate'])) {
+    forum_require_permission($forumId, 'can_moderate');
+    // process moderation actions here
 }
 
 $pageCSS = "../static/css/forum.css";


### PR DESCRIPTION
## Summary
- add `core/forum.php` with helper functions to determine user roles, fetch permissions, and enforce forum access
- validate `can_view`, `can_post`, and `can_moderate` before rendering or posting
- show login page or 403 Forbidden based on permission status

## Testing
- `php -l core/forum.php`
- `php -l public/forum.php`
- `php -l public/forum/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6894cf7195448321bdb41542a89fc0bc