### PR TITLE
Store rank in session during login

### DIFF
--- a/admin/login.php
+++ b/admin/login.php
@@ -11,7 +11,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['action'])) {
 
         if ($_POST['action'] == 'login') {
             // Prepare SQL statement for login
-            $stmt = $conn->prepare("SELECT id, username, password FROM users WHERE email = ?");
+            $stmt = $conn->prepare("SELECT id, username, password, rank FROM users WHERE email = ?");
             $stmt->execute(array($email));
             $user = $stmt->fetch(PDO::FETCH_ASSOC);
 
@@ -20,6 +20,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['action'])) {
             if (($user && password_verify($password, $user['password'])) && $isAdmin) {
                 $_SESSION['user'] = $user['username'];
                 $_SESSION['userId'] = $user['id'];
+                $_SESSION['rank'] = $user['rank'];
 
                 header("Location: index.php");
                 exit;

--- a/admin/logout.php
+++ b/admin/logout.php
@@ -2,6 +2,7 @@
 session_start(); // Start or resume the session
 
 // Unset all session variables
+unset($_SESSION['user'], $_SESSION['userId'], $_SESSION['rank']);
 $_SESSION = array();
 
 // If it's desired to kill the session, also delete the session cookie

--- a/public/index.php
+++ b/public/index.php
@@ -22,13 +22,14 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['action'])) {
         $password = $_POST['password'];
 
 
-        $stmt = $conn->prepare("SELECT id, username, password FROM users WHERE email = ?");
+        $stmt = $conn->prepare("SELECT id, username, password, rank FROM users WHERE email = ?");
         $stmt->execute(array($email));
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
 
         if ($user && password_verify($password, $user['password'])) {
             $_SESSION['user'] = $user['username'];
             $_SESSION['userId'] = $user['id'];
+            $_SESSION['rank'] = $user['rank'];
             header("Location: home.php");
             exit;
         } else {

--- a/public/login.php
+++ b/public/login.php
@@ -11,7 +11,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['action'])) {
 
         if ($_POST['action'] == 'login') {
             // Prepare SQL statement for login
-            $stmt = $conn->prepare("SELECT id, username, password FROM users WHERE email = ?");
+            $stmt = $conn->prepare("SELECT id, username, password, rank FROM users WHERE email = ?");
             $stmt->execute(array($email));
             $user = $stmt->fetch(PDO::FETCH_ASSOC);
 
@@ -19,6 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['action'])) {
             if ($user && password_verify($password, $user['password'])) {
                 $_SESSION['user'] = $user['username'];
                 $_SESSION['userId'] = $user['id'];
+                $_SESSION['rank'] = $user['rank'];
 
                 header("Location: home.php");
                 exit;

--- a/public/logout.php
+++ b/public/logout.php
@@ -2,6 +2,7 @@
 session_start(); // Start or resume the session
 
 // Unset all session variables
+unset($_SESSION['user'], $_SESSION['userId'], $_SESSION['rank']);
 $_SESSION = array();
 
 // If it's desired to kill the session, also delete the session cookie


### PR DESCRIPTION
## Summary
- Query user rank during login and store it in the session
- Clear stored rank on logout for both public and admin areas

## Testing
- `php -l public/index.php`
- `php -l public/login.php`
- `php -l admin/login.php`
- `php -l public/logout.php`
- `php -l admin/logout.php`


------
https://chatgpt.com/codex/tasks/task_e_6894d3d18314832193da0ee948ad4610