### PR TITLE
feat: add forum theme customization

### DIFF
--- a/core/forum.php
+++ b/core/forum.php
@@ -56,4 +56,26 @@ function forum_require_permission($forum_id, $flag) {
     }
     return true;
 }
+
+function forum_get_user_settings($user_id) {
+    global $conn;
+    $stmt = $conn->prepare('SELECT background_image_url, background_color, text_color FROM forum_user_settings WHERE user_id = :uid');
+    $stmt->execute([':uid' => $user_id]);
+    $settings = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$settings) {
+        $settings = ['background_image_url' => '', 'background_color' => '', 'text_color' => ''];
+    }
+    return $settings;
+}
+
+function forum_save_user_settings($user_id, $bg_url, $bg_color, $text_color) {
+    global $conn;
+    $stmt = $conn->prepare('INSERT INTO forum_user_settings (user_id, background_image_url, background_color, text_color) VALUES (:uid, :bg_url, :bg_color, :text_color) ON DUPLICATE KEY UPDATE background_image_url = VALUES(background_image_url), background_color = VALUES(background_color), text_color = VALUES(text_color)');
+    $stmt->execute([
+        ':uid' => $user_id,
+        ':bg_url' => $bg_url,
+        ':bg_color' => $bg_color,
+        ':text_color' => $text_color
+    ]);
+}
 ?>

--- a/public/forum/index.php
+++ b/public/forum/index.php
@@ -6,6 +6,11 @@ require_once("../../core/forum.php");
 $forumId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 forum_require_permission($forumId, 'can_view');
 
+$userSettings = ['background_image_url' => '', 'background_color' => '', 'text_color' => ''];
+if (isset($_SESSION['userId'])) {
+    $userSettings = forum_get_user_settings($_SESSION['userId']);
+}
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     forum_require_permission($forumId, 'can_post');
     // process post submission here
@@ -20,8 +25,27 @@ $pageCSS = "../static/css/forum.css";
 ?>
 <?php require("../header.php"); ?>
 
+<?php if (!empty($userSettings['background_image_url']) || !empty($userSettings['background_color']) || !empty($userSettings['text_color'])): ?>
+<style>
+body {
+<?php if (!empty($userSettings['background_image_url'])): ?>
+    background-image: url('<?= htmlspecialchars($userSettings['background_image_url'], ENT_QUOTES) ?>');
+<?php endif; ?>
+<?php if (!empty($userSettings['background_color'])): ?>
+    background-color: <?= htmlspecialchars($userSettings['background_color'], ENT_QUOTES) ?>;
+<?php endif; ?>
+<?php if (!empty($userSettings['text_color'])): ?>
+    color: <?= htmlspecialchars($userSettings['text_color'], ENT_QUOTES) ?>;
+<?php endif; ?>
+}
+</style>
+<?php endif; ?>
+
 <div class="simple-container">
     <h1>Forums</h1>
+    <?php if (isset($_SESSION['userId'])): ?>
+    <p><a href="settings.php">Customize Forum</a></p>
+    <?php endif; ?>
     <?php
     $threads = [
         ['status' => 'new', 'title' => 'Welcome to the forums', 'posts' => 3, 'last' => 'Aug 7 by Admin'],

--- a/public/forum/settings.php
+++ b/public/forum/settings.php
@@ -1,0 +1,59 @@
+<?php
+require("../../core/conn.php");
+require_once("../../core/settings.php");
+require_once("../../core/forum.php");
+
+login_check();
+
+$userId = $_SESSION['userId'];
+$settings = forum_get_user_settings($userId);
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $bgUrl = trim($_POST['background_url'] ?? '');
+    $bgColor = trim($_POST['background_color'] ?? '');
+    $textColor = trim($_POST['text_color'] ?? '');
+
+    if ($bgUrl && !filter_var($bgUrl, FILTER_VALIDATE_URL)) {
+        $bgUrl = '';
+    }
+    if ($bgColor && !preg_match('/^#[0-9a-fA-F]{6}$/', $bgColor)) {
+        $bgColor = '';
+    }
+    if ($textColor && !preg_match('/^#[0-9a-fA-F]{6}$/', $textColor)) {
+        $textColor = '';
+    }
+
+    forum_save_user_settings($userId, $bgUrl, $bgColor, $textColor);
+    $settings = ['background_image_url' => $bgUrl, 'background_color' => $bgColor, 'text_color' => $textColor];
+    $message = "Settings saved.";
+}
+
+$pageCSS = "../static/css/forum.css";
+require("../header.php");
+?>
+<div class="simple-container">
+    <h1>Forum Settings</h1>
+    <?php if (!empty($message)): ?>
+    <p><?= htmlspecialchars($message) ?></p>
+    <?php endif; ?>
+    <form method="post">
+        <p>
+            <label>Background Image URL:<br>
+                <input type="text" name="background_url" value="<?= htmlspecialchars($settings['background_image_url'] ?? '') ?>">
+            </label>
+        </p>
+        <p>
+            <label>Background Color:<br>
+                <input type="text" name="background_color" value="<?= htmlspecialchars($settings['background_color'] ?? '') ?>" placeholder="#ffffff">
+            </label>
+        </p>
+        <p>
+            <label>Text Color:<br>
+                <input type="text" name="text_color" value="<?= htmlspecialchars($settings['text_color'] ?? '') ?>" placeholder="#000000">
+            </label>
+        </p>
+        <p><input type="submit" value="Save"></p>
+    </form>
+</div>
+<?php require("../footer.php"); ?>

--- a/schema.sql
+++ b/schema.sql
@@ -305,3 +305,16 @@ INSERT INTO `users` (`id`, `rank`, `username`, `email`, `password`, `date`, `bio
 VALUES (1, 1, 'globalmod', 'globalmod@example.com', '$2y$12$ocAW8xAoEHay8ElZLzsFOuP5EM9t1YyGdslYQD/EXcNLLU1VmVGSS', NOW(), '', ' ', '', 'default.mp3', 'default.jpg', 'None', '', 0, 0, NOW(), NOW());
 
 INSERT INTO `forum_moderators` (`forum_id`, `user_id`) VALUES (1, 1);
+
+-- --------------------------------------------------------
+--
+-- Table structure for table `forum_user_settings`
+--
+CREATE TABLE IF NOT EXISTS `forum_user_settings` (
+  `user_id` int(11) NOT NULL,
+  `background_image_url` varchar(255) DEFAULT NULL,
+  `background_color` varchar(7) DEFAULT NULL,
+  `text_color` varchar(7) DEFAULT NULL,
+  PRIMARY KEY (`user_id`),
+  FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
## Summary
- allow users to store forum theme settings (background image & colors)
- apply user-specific styles on forum pages
- add forum settings page for users to configure these options

## Testing
- `php -l core/forum.php`
- `php -l public/forum/index.php`
- `php -l public/forum/settings.php`


------
https://chatgpt.com/codex/tasks/task_e_6894da7317fc83218c9e889d05f21379