### PR TITLE
Add forum topic locking support

### DIFF
--- a/core/forum/post.php
+++ b/core/forum/post.php
@@ -1,0 +1,17 @@
+<?php
+
+function forum_add_post(int $topic_id, int $user_id, string $body)
+{
+    global $conn;
+    $stmt = $conn->prepare('SELECT locked FROM forum_topics WHERE id = :id');
+    $stmt->execute([':id' => $topic_id]);
+    $locked = (int)$stmt->fetchColumn();
+    if ($locked === 1) {
+        return ['error' => 'Topic is locked'];
+    }
+    $insert = $conn->prepare('INSERT INTO forum_posts (topic_id, user_id, body, created_at) VALUES (:tid, :uid, :body, NOW())');
+    $insert->execute([':tid' => $topic_id, ':uid' => $user_id, ':body' => $body]);
+    return ['success' => true];
+}
+
+?>

--- a/core/forum/topic.php
+++ b/core/forum/topic.php
@@ -1,0 +1,23 @@
+<?php
+
+function forum_log_action(string $message): void {
+    $logFile = __DIR__ . '/../../admin_logs.txt';
+    $entry = date('c') . ' ' . $message . PHP_EOL;
+    file_put_contents($logFile, $entry, FILE_APPEND);
+}
+
+function topic_lock(int $topic_id, int $by_user_id): void {
+    global $conn;
+    $stmt = $conn->prepare('UPDATE forum_topics SET locked = 1 WHERE id = :id');
+    $stmt->execute([':id' => $topic_id]);
+    forum_log_action("User {$by_user_id} locked topic {$topic_id}");
+}
+
+function topic_unlock(int $topic_id, int $by_user_id): void {
+    global $conn;
+    $stmt = $conn->prepare('UPDATE forum_topics SET locked = 0 WHERE id = :id');
+    $stmt->execute([':id' => $topic_id]);
+    forum_log_action("User {$by_user_id} unlocked topic {$topic_id}");
+}
+
+?>

--- a/public/forum/topic.php
+++ b/public/forum/topic.php
@@ -1,0 +1,74 @@
+<?php
+require("../../core/conn.php");
+require_once("../../core/settings.php");
+require_once("../../core/forum.php");
+require_once("../../core/forum/topic.php");
+require_once("../../core/forum/post.php");
+
+$topicId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $conn->prepare('SELECT id, forum_id, title, locked FROM forum_topics WHERE id = :id');
+$stmt->execute([':id' => $topicId]);
+$topic = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$topic) {
+    echo 'Topic not found';
+    exit;
+}
+
+$perms = forum_fetch_permissions($topic['forum_id']);
+$can_moderate = !empty($perms['can_moderate']);
+$can_post = !empty($perms['can_post']);
+$error = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['lock']) && $can_moderate) {
+        topic_lock($topicId, $_SESSION['userId']);
+        header('Location: topic.php?id=' . $topicId);
+        exit;
+    }
+    if (isset($_POST['unlock']) && $can_moderate) {
+        topic_unlock($topicId, $_SESSION['userId']);
+        header('Location: topic.php?id=' . $topicId);
+        exit;
+    }
+    if (isset($_POST['body'])) {
+        forum_require_permission($topic['forum_id'], 'can_post');
+        $result = forum_add_post($topicId, $_SESSION['userId'], $_POST['body']);
+        if (isset($result['error'])) {
+            $error = $result['error'];
+        } else {
+            header('Location: topic.php?id=' . $topicId);
+            exit;
+        }
+    }
+}
+
+$pageCSS = "../static/css/forum.css";
+?>
+<?php require("../header.php"); ?>
+<div class="simple-container">
+    <h1><?= htmlspecialchars($topic['title']) ?></h1>
+
+    <?php if ($can_moderate): ?>
+    <form method="post" style="display:inline">
+        <?php if ($topic['locked']): ?>
+            <button type="submit" name="unlock">Unlock Topic</button>
+        <?php else: ?>
+            <button type="submit" name="lock">Lock Topic</button>
+        <?php endif; ?>
+    </form>
+    <?php endif; ?>
+
+    <?php if ($error): ?>
+        <div class="alert"><?= htmlspecialchars($error) ?></div>
+    <?php endif; ?>
+
+    <?php if (!$topic['locked'] && $can_post): ?>
+    <form method="post">
+        <textarea name="body"></textarea>
+        <button type="submit">Post</button>
+    </form>
+    <?php elseif ($topic['locked']): ?>
+        <p>This topic is locked.</p>
+    <?php endif; ?>
+</div>
+<?php require("../footer.php"); ?>

--- a/schema.sql
+++ b/schema.sql
@@ -269,6 +269,19 @@ CREATE TABLE IF NOT EXISTS `forums` (
 
 -- --------------------------------------------------------
 --
+-- Table structure for table `forum_topics`
+--
+CREATE TABLE IF NOT EXISTS `forum_topics` (
+  `id` int(11) NOT NULL auto_increment,
+  `forum_id` int(11) NOT NULL,
+  `title` varchar(255) NOT NULL,
+  `locked` tinyint(1) NOT NULL default '0',
+  PRIMARY KEY (`id`),
+  FOREIGN KEY (`forum_id`) REFERENCES `forums` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- --------------------------------------------------------
+--
 -- Table structure for table `forum_permissions`
 --
 CREATE TABLE IF NOT EXISTS `forum_permissions` (


### PR DESCRIPTION
## Summary
- create forum_topics table with a locked flag
- add topic_lock / topic_unlock helpers with logging
- expose lock/unlock in forum topic page and block posting to locked topics

## Testing
- `php -l core/forum/topic.php`
- `php -l core/forum/post.php`
- `php -l public/forum/topic.php`


------
https://chatgpt.com/codex/tasks/task_e_6894dd86c014832182d56ec0f31bb637