### PR TITLE
Implement soft deletion for forum posts

### DIFF
--- a/core/forum/post.php
+++ b/core/forum/post.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once(__DIR__ . '/topic.php');
+
 function forum_add_post(int $topic_id, int $user_id, string $body)
 {
     global $conn;
@@ -12,6 +14,22 @@ function forum_add_post(int $topic_id, int $user_id, string $body)
     $insert = $conn->prepare('INSERT INTO forum_posts (topic_id, user_id, body, created_at) VALUES (:tid, :uid, :body, NOW())');
     $insert->execute([':tid' => $topic_id, ':uid' => $user_id, ':body' => $body]);
     return ['success' => true];
+}
+
+function post_soft_delete(int $post_id, int $by_user_id): void
+{
+    global $conn;
+    $stmt = $conn->prepare('UPDATE forum_posts SET deleted = 1, deleted_by = :uid, deleted_at = NOW() WHERE id = :id');
+    $stmt->execute([':id' => $post_id, ':uid' => $by_user_id]);
+    forum_log_action("User {$by_user_id} deleted post {$post_id}");
+}
+
+function post_restore(int $post_id, int $by_user_id): void
+{
+    global $conn;
+    $stmt = $conn->prepare('UPDATE forum_posts SET deleted = 0, deleted_by = NULL, deleted_at = NULL WHERE id = :id');
+    $stmt->execute([':id' => $post_id]);
+    forum_log_action("User {$by_user_id} restored post {$post_id}");
 }
 
 ?>

--- a/schema.sql
+++ b/schema.sql
@@ -282,6 +282,24 @@ CREATE TABLE IF NOT EXISTS `forum_topics` (
 
 -- --------------------------------------------------------
 --
+-- Table structure for table `forum_posts`
+--
+CREATE TABLE IF NOT EXISTS `forum_posts` (
+  `id` int(11) NOT NULL auto_increment,
+  `topic_id` int(11) NOT NULL,
+  `user_id` int(11) NOT NULL,
+  `body` text NOT NULL,
+  `created_at` datetime NOT NULL,
+  `deleted` TINYINT(1) DEFAULT 0,
+  `deleted_by` INT DEFAULT NULL,
+  `deleted_at` DATETIME DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  FOREIGN KEY (`topic_id`) REFERENCES `forum_topics` (`id`),
+  FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- --------------------------------------------------------
+--
 -- Table structure for table `forum_permissions`
 --
 CREATE TABLE IF NOT EXISTS `forum_permissions` (


### PR DESCRIPTION
## Summary
- add `forum_posts` table with soft delete metadata
- enable moderators to soft delete or restore posts and log actions
- hide deleted posts from regular users and show Delete/Restore controls for moderators

## Testing
- `php -l core/forum/post.php`
- `php -l public/forum/topic.php`


------
https://chatgpt.com/codex/tasks/task_e_6894deb8d4c48321b621b791c977d3e8