### PR TITLE
Add forum permission checks for viewing topics

### DIFF
--- a/public/forum/post.php
+++ b/public/forum/post.php
@@ -15,7 +15,10 @@ if (!$topic) {
     exit;
 }
 
-$perms = forum_fetch_permissions($topic['forum_id']);
+$forumId = (int)$topic['forum_id'];
+forum_require_permission($forumId, 'can_view');
+
+$perms = forum_fetch_permissions($forumId);
 $can_post = !empty($perms['can_post']);
 $can_moderate = !empty($perms['can_moderate']);
 $error = '';


### PR DESCRIPTION
## Summary
- Ensure viewing a topic's posts requires forum permissions
- Leverage forum permission helpers to restrict access

## Testing
- `php tests/forum_permissions.php`


------
https://chatgpt.com/codex/tasks/task_e_6894fb4da8988321929a82f0cb6ac988