### PR TITLE
style: enhance forum layout

### DIFF
--- a/core/site/forum.php
+++ b/core/site/forum.php
@@ -26,7 +26,7 @@ function renderForumPost(array $post)
     if (!empty($user['lastactive'])) {
         $lastActive = strtotime($user['lastactive']);
         if ($lastActive !== false && (time() - $lastActive) <= 300) {
-            $badge = '<img class="online-badge" src="static/img/online_now.gif" alt="Online Now" loading="lazy">';
+            $badge = '<img class="online-badge" src="static/img/green_person.png" alt="Online Now" loading="lazy">';
         }
     }
 

--- a/public/forum/topic.php
+++ b/public/forum/topic.php
@@ -56,7 +56,8 @@ $pageCSS = "../static/css/forum.css";
 <div class="simple-container">
     <h1>Topics</h1>
     <table class="forum-table">
-        <tr>
+        <tr class="forum-header">
+            <th></th>
             <th>Topic</th>
             <th>Posts</th>
             <th>Last Post</th>
@@ -65,6 +66,7 @@ $pageCSS = "../static/css/forum.css";
         <?php foreach ($topics as $t): ?>
         <?php $linkId = $t['moved_to'] ? $t['moved_to'] : $t['id']; ?>
         <tr>
+            <td class="icon-cell"><img src="../static/img/divider_o.png" alt="Thread" loading="lazy"></td>
             <td><a href="post.php?id=<?= $linkId ?>"><?= htmlspecialchars($t['title']) ?></a></td>
             <td><?= (int)$t['posts'] ?></td>
             <td><?= htmlspecialchars($t['last_post']) ?></td>

--- a/public/static/css/forum.css
+++ b/public/static/css/forum.css
@@ -18,6 +18,43 @@ body {
     color: #fff;
 }
 
+/* Generic forum tables */
+.forum-table,
+.post-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1em;
+}
+
+.forum-table th,
+.forum-table td,
+.post-table th,
+.post-table td {
+    padding: 8px;
+    border: 1px solid var(--light-gray);
+}
+
+.forum-table tr:nth-child(even),
+.post-table tr:nth-child(even) {
+    background-color: var(--even-lighter-blue);
+}
+
+.forum-table tr:nth-child(odd),
+.post-table tr:nth-child(odd) {
+    background-color: var(--even-lighter-orange);
+}
+
+/* Vintage thread icon */
+.forum-table .icon-cell {
+    width: 20px;
+    text-align: center;
+}
+
+.forum-table .icon-cell img {
+    width: 16px;
+    height: 16px;
+}
+
 .forum-post .avatar {
     width: 50px;
     height: 50px;
@@ -33,4 +70,30 @@ body {
     position: absolute;
     bottom: 0;
     right: 0;
+}
+
+/* Post table avatar column */
+.post-table .avatar-cell {
+    width: 70px;
+    vertical-align: top;
+}
+
+.post-table .avatar-wrapper {
+    position: relative;
+    display: inline-block;
+}
+
+.post-table .avatar {
+    width: 50px;
+    height: 50px;
+    object-fit: cover;
+    display: block;
+}
+
+.post-table .online-badge {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 16px;
+    height: 16px;
 }


### PR DESCRIPTION
## Summary
- style forum with blue-orange gradients, vintage thread icons, and table layouts
- render topic list rows with classic icons
- display posts in tables with avatars and "Online Now" badges

## Testing
- `php -l public/forum/topic.php`
- `php -l public/forum/post.php`
- `php -l core/site/forum.php`
- `php tests/forum_permissions.php >/tmp/test_output.txt && tail -n 20 /tmp/test_output.txt`


------
https://chatgpt.com/codex/tasks/task_e_6894fdf683bc8321a132f79f838ec1f7