### PR TITLE
Remove orphaned forum data on forum deletion

### DIFF
--- a/admin/forum/categories.php
+++ b/admin/forum/categories.php
@@ -1,11 +1,7 @@
 <?php
 require("../../core/conn.php");
 require_once("../../core/settings.php");
-
-if (!isset($_SESSION['user'])) {
-    header("Location: ../login.php");
-    exit;
-}
+admin_only();
 
 require("../../core/config.php");
 

--- a/admin/forum/forums.php
+++ b/admin/forum/forums.php
@@ -1,28 +1,13 @@
 <?php
 require("../../core/conn.php");
 require_once("../../core/settings.php");
-
-if (!isset($_SESSION['user'])) {
-    header("Location: ../login.php");
-    exit;
-}
-
 require("../../core/config.php");
+require_once("../../core/forum/forum.php");
 
-// Recursive deletion of forum and its subforums
-function deleteForum(PDO $conn, int $id): void {
-    // delete children first
-    $childStmt = $conn->prepare('SELECT id FROM forums WHERE parent_forum_id = :id');
-    $childStmt->execute([':id' => $id]);
-    $children = $childStmt->fetchAll(PDO::FETCH_COLUMN);
-    foreach ($children as $childId) {
-        deleteForum($conn, (int)$childId);
-    }
-    // delete permissions then this forum
-    $permDel = $conn->prepare('DELETE FROM forum_permissions WHERE forum_id = :id');
-    $permDel->execute([':id' => $id]);
-    $delStmt = $conn->prepare('DELETE FROM forums WHERE id = :id');
-    $delStmt->execute([':id' => $id]);
+login_check();
+if (!isset($_SESSION['userId']) || $_SESSION['userId'] != ADMIN_USER) {
+    header("Location: ../index.php?msg=" . urlencode('Admin access required'));
+    exit;
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -112,7 +97,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['delete'])) {
         $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
         if ($id > 0) {
-            deleteForum($conn, $id);
+            forum_delete_forum($id);
             header('Location: forums.php?msg=' . urlencode('Forum deleted'));
             exit;
         }

--- a/admin/forum/forums.php
+++ b/admin/forum/forums.php
@@ -3,12 +3,7 @@ require("../../core/conn.php");
 require_once("../../core/settings.php");
 require("../../core/config.php");
 require_once("../../core/forum/forum.php");
-
-login_check();
-if (!isset($_SESSION['userId']) || $_SESSION['userId'] != ADMIN_USER) {
-    header("Location: ../index.php?msg=" . urlencode('Admin access required'));
-    exit;
-}
+admin_only();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // Add forum

--- a/admin/forum/global_mods.php
+++ b/admin/forum/global_mods.php
@@ -1,12 +1,7 @@
 <?php
 require("../../core/conn.php");
 require_once("../../core/settings.php");
-
-login_check();
-if (!isset($_SESSION['userId']) || $_SESSION['userId'] != ADMIN_USER) {
-    header("Location: ../index.php?msg=" . urlencode('Admin access required'));
-    exit;
-}
+admin_only();
 
 require("../../core/config.php");
 

--- a/admin/forum/moderators.php
+++ b/admin/forum/moderators.php
@@ -1,12 +1,7 @@
 <?php
 require("../../core/conn.php");
 require_once("../../core/settings.php");
-
-login_check();
-if (!isset($_SESSION['userId']) || $_SESSION['userId'] != ADMIN_USER) {
-    header("Location: ../index.php?msg=" . urlencode('Admin access required'));
-    exit;
-}
+admin_only();
 
 require("../../core/config.php");
 

--- a/admin/forum/permissions.php
+++ b/admin/forum/permissions.php
@@ -1,11 +1,7 @@
 <?php
 require("../../core/conn.php");
 require_once("../../core/settings.php");
-
-if (!isset($_SESSION['user'])) {
-    header("Location: ../login.php");
-    exit;
-}
+admin_only();
 
 require("../../core/config.php");
 

--- a/core/helper.php
+++ b/core/helper.php
@@ -6,6 +6,13 @@ function login_check() {
     }
 }
 
+function admin_only() {
+    if (!isset($_SESSION['userId']) || (defined('ADMIN_USER') && $_SESSION['userId'] != ADMIN_USER)) {
+        header("Location: /admin/login.php?msg=" . urlencode('Admin access required'));
+        exit;
+    }
+}
+
 function validateContentHTML($validate) {
     // Whitelisted tags
     $allowedTags = '<a><b><big><blockquote><blink><br><center><code><del><details><div><em><font><h1><h2><h3><h4><h5><h6><hr><i><iframe><img><li><mark><marquee><ol><p><pre><small><span><strong><style><sub><summary><sup><table><td><th><time><tr><u><ul>';

--- a/tests/forum_delete.php
+++ b/tests/forum_delete.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__.'/../core/forum/forum.php';
+
+// in-memory database for testing
+$conn = new PDO('sqlite::memory:');
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+global $conn;
+
+$conn->exec('CREATE TABLE forums (id INTEGER PRIMARY KEY, category_id INTEGER, parent_forum_id INTEGER)');
+$conn->exec('CREATE TABLE forum_topics (id INTEGER PRIMARY KEY, forum_id INTEGER)');
+$conn->exec('CREATE TABLE forum_posts (id INTEGER PRIMARY KEY, topic_id INTEGER)');
+$conn->exec('CREATE TABLE forum_moderators (forum_id INTEGER, user_id INTEGER)');
+$conn->exec('CREATE TABLE forum_permissions (forum_id INTEGER, role TEXT, can_view INTEGER, can_post INTEGER, can_moderate INTEGER)');
+
+// seed forum with a child, topics, posts, moderator and permissions
+$conn->exec("INSERT INTO forums (id, category_id, parent_forum_id) VALUES (1,1,NULL)");
+$conn->exec("INSERT INTO forums (id, category_id, parent_forum_id) VALUES (2,1,1)");
+$conn->exec("INSERT INTO forum_topics (id, forum_id) VALUES (1,1)");
+$conn->exec("INSERT INTO forum_topics (id, forum_id) VALUES (2,2)");
+$conn->exec("INSERT INTO forum_posts (id, topic_id) VALUES (1,1)");
+$conn->exec("INSERT INTO forum_posts (id, topic_id) VALUES (2,2)");
+$conn->exec("INSERT INTO forum_moderators (forum_id, user_id) VALUES (1,10)");
+$conn->exec("INSERT INTO forum_permissions (forum_id, role, can_view, can_post, can_moderate) VALUES (1,'member',1,1,0)");
+
+forum_delete_forum(1);
+
+$tables = ['forums','forum_topics','forum_posts','forum_moderators','forum_permissions'];
+$remaining = [];
+foreach ($tables as $t) {
+    $remaining[$t] = $conn->query("SELECT COUNT(*) FROM $t")->fetchColumn();
+}
+
+if (array_sum($remaining) === 0) {
+    echo "Deletion cascade OK\n";
+} else {
+    echo 'Deletion cascade failed: ' . json_encode($remaining) . "\n";
+}
+


### PR DESCRIPTION
## Summary
- Move recursive forum deletion into core to purge related topics, posts, permissions, and moderator assignments
- Enforce login check and admin guard in forum admin page

## Testing
- `php tests/forum_permissions.php`
- `php tests/forum_delete.php`


------
https://chatgpt.com/codex/tasks/task_e_689439197e28832188a62d38937025ee