### PR TITLE
Add integration test for forum public page

### DIFF
--- a/core/conn.php
+++ b/core/conn.php
@@ -1,11 +1,23 @@
 <?php
-require_once("config.php");
+
+// Allow test environments to provide a custom DSN via the DB_DSN
+// environment variable. When present, configuration variables are
+// not required and optional DB_USER/DB_PASS variables may supply
+// credentials. Otherwise fall back to the default MySQL configuration
+// loaded from config.php.
+if (($dsn = getenv('DB_DSN')) !== false) {
+    $username = getenv('DB_USER') ?: null;
+    $password = getenv('DB_PASS') ?: null;
+} else {
+    require_once("config.php");
+    $dsn = "mysql:host=$host;dbname=$dbname";
+}
 
 try {
-    $conn = new PDO("mysql:host=$host;dbname=$dbname", $username, $password);
+    $conn = new PDO($dsn, $username, $password);
     // Set the PDO error mode to exception
     $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-} catch(PDOException $e) {
+} catch (PDOException $e) {
     echo "Connection failed: ", $e->getMessage();
 }
 ?>

--- a/public/forum/forums.php
+++ b/public/forum/forums.php
@@ -1,14 +1,14 @@
 <?php
-require("../../core/conn.php");
-require_once("../../core/settings.php");
-require_once("../../core/forum/category.php");
-require_once("../../core/forum/forum.php");
-require_once("../../core/forum/permissions.php");
+require __DIR__ . "/../../core/conn.php";
+require_once __DIR__ . "/../../core/settings.php";
+require_once __DIR__ . "/../../core/forum/category.php";
+require_once __DIR__ . "/../../core/forum/forum.php";
+require_once __DIR__ . "/../../core/forum/permissions.php";
 
 $pageCSS = "../static/css/forum.css";
 $categories = forum_get_categories();
 ?>
-<?php require("../header.php"); ?>
+<?php require __DIR__ . "/../header.php"; ?>
 <div class="simple-container">
     <h1>Forums</h1>
     <?php foreach ($categories as $cat): ?>
@@ -16,4 +16,4 @@ $categories = forum_get_categories();
 
     <?php endforeach; ?>
 </div>
-<?php require("../footer.php"); ?>
+<?php require __DIR__ . "/../footer.php"; ?>

--- a/public/header.php
+++ b/public/header.php
@@ -62,5 +62,5 @@
 
 <body>
     <div class="master-container">
-        <?php require_once("../core/components/navbar.php"); ?>
+        <?php require_once __DIR__ . "/../core/components/navbar.php"; ?>
         <main>

--- a/tests/forum_public.php
+++ b/tests/forum_public.php
@@ -1,0 +1,39 @@
+<?php
+// Integration test for public forum listing page.
+// Uses SQLite to avoid external dependencies.
+
+// Setup SQLite database in a temporary file and configure connection
+$dbFile = __DIR__ . '/forum_test.db';
+@unlink($dbFile);
+$dsn = 'sqlite:' . $dbFile;
+putenv('DB_DSN=' . $dsn);
+
+// Establish connection and seed data
+$conn = new PDO($dsn);
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$conn->exec('CREATE TABLE forum_categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, position INTEGER)');
+$conn->exec("INSERT INTO forum_categories (name, position) VALUES ('General', 1)");
+
+// Settings variables expected by settings.php
+$siteName = 'AnySpace';
+$domainName = 'example.com';
+$adminUser = 1;
+
+global $conn;
+
+// Capture output of the forums page
+ob_start();
+require __DIR__ . '/../public/forum/forums.php';
+$output = ob_get_clean();
+
+// Simple assertions
+if (strpos($output, '<h1>Forums</h1>') !== false && strpos($output, 'General') !== false) {
+    echo "Forums page displays categories\n";
+} else {
+    echo "Forums page test failed\n";
+    exit(1);
+}
+
+// Cleanup temporary database
+unlink($dbFile);
+


### PR DESCRIPTION
## Summary
- allow database DSN override through environment variables
- fix header and forum page includes to use absolute paths
- add integration test covering public forums page rendering

## Testing
- `php tests/forum_delete.php`
- `php tests/forum_permissions.php`
- `php tests/forum_public.php`


------
https://chatgpt.com/codex/tasks/task_e_68950f60749083219ea76582340f4370