### PR TITLE
Add forum search feature

### DIFF
--- a/core/forum/forum.php
+++ b/core/forum/forum.php
@@ -56,4 +56,11 @@ function forum_delete_forum(int $id): void {
     $stmt->execute([':id' => $id]);
 }
 
+function searchTopics(string $query): array {
+    global $conn;
+    $stmt = $conn->prepare('SELECT DISTINCT t.id, t.title FROM forum_topics t LEFT JOIN forum_posts p ON t.id = p.topic_id WHERE t.title LIKE :search OR p.body LIKE :search ORDER BY t.id DESC');
+    $stmt->execute([':search' => "%" . $query . "%"]);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
 ?>

--- a/public/forum/index.php
+++ b/public/forum/index.php
@@ -1,2 +1,22 @@
 <?php
-require_once __DIR__ . '/forums.php';
+require __DIR__ . "/../../core/conn.php";
+require_once __DIR__ . "/../../core/settings.php";
+require_once __DIR__ . "/../../core/forum/category.php";
+require_once __DIR__ . "/../../core/forum/forum.php";
+require_once __DIR__ . "/../../core/forum/permissions.php";
+
+$pageCSS = "../static/css/forum.css";
+$categories = forum_get_categories();
+?>
+<?php require __DIR__ . "/../header.php"; ?>
+<div class="simple-container">
+    <h1>Forums</h1>
+    <form class="forum-search" action="search.php" method="get">
+        <input type="text" name="q">
+        <button type="submit">Search</button>
+    </form>
+    <?php foreach ($categories as $cat): ?>
+        <h2><?= htmlspecialchars($cat['name']) ?></h2>
+    <?php endforeach; ?>
+</div>
+<?php require __DIR__ . "/../footer.php"; ?>

--- a/public/forum/search.php
+++ b/public/forum/search.php
@@ -1,0 +1,33 @@
+<?php
+require __DIR__ . "/../../core/conn.php";
+require_once __DIR__ . "/../../core/settings.php";
+require_once __DIR__ . "/../../core/forum/forum.php";
+
+$pageCSS = "../static/css/forum.css";
+
+$query = isset($_GET['q']) ? trim($_GET['q']) : '';
+$results = [];
+if ($query !== '') {
+    $results = searchTopics($query);
+}
+?>
+<?php require __DIR__ . "/../header.php"; ?>
+<div class="simple-container">
+    <h1>Forum Search</h1>
+    <form class="forum-search" action="search.php" method="get">
+        <input type="text" name="q" value="<?= htmlspecialchars($query) ?>">
+        <button type="submit">Search</button>
+    </form>
+    <?php if ($query !== ''): ?>
+        <?php if (!empty($results)): ?>
+            <ul>
+                <?php foreach ($results as $topic): ?>
+                    <li><a href="topic.php?id=<?= $topic['id'] ?>"><?= htmlspecialchars($topic['title']) ?></a></li>
+                <?php endforeach; ?>
+            </ul>
+        <?php else: ?>
+            <p>No results found.</p>
+        <?php endif; ?>
+    <?php endif; ?>
+</div>
+<?php require __DIR__ . "/../footer.php"; ?>

--- a/public/static/css/forum.css
+++ b/public/static/css/forum.css
@@ -97,3 +97,9 @@ body {
     width: 16px;
     height: 16px;
 }
+
+/* Forum search input */
+.forum-search input[type="text"] {
+    padding: 4px;
+    border: 1px solid var(--light-gray);
+}

--- a/tests/forum_public.php
+++ b/tests/forum_public.php
@@ -20,7 +20,8 @@ $domainName = 'example.com';
 $adminUser = 1;
 
 global $conn;
-
+ob_start();
+require __DIR__ . '/../public/forum/index.php';
 $output = ob_get_clean();
 
 // Simple assertions

--- a/tests/forum_search.php
+++ b/tests/forum_search.php
@@ -1,0 +1,36 @@
+<?php
+// Integration test for forum search functionality.
+
+$dbFile = __DIR__ . '/forum_search.db';
+@unlink($dbFile);
+$dsn = 'sqlite:' . $dbFile;
+putenv('DB_DSN=' . $dsn);
+
+$conn = new PDO($dsn);
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$conn->exec('CREATE TABLE forum_topics (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT)');
+$conn->exec('CREATE TABLE forum_posts (id INTEGER PRIMARY KEY AUTOINCREMENT, topic_id INTEGER, body TEXT)');
+$conn->exec("INSERT INTO forum_topics (title) VALUES ('Hello World')");
+$conn->exec("INSERT INTO forum_posts (topic_id, body) VALUES (1, 'First post body')");
+$conn->exec("INSERT INTO forum_topics (title) VALUES ('Another Topic')");
+$conn->exec("INSERT INTO forum_posts (topic_id, body) VALUES (2, 'Something else')");
+
+$siteName = 'AnySpace';
+$domainName = 'example.com';
+$adminUser = 1;
+
+global $conn;
+
+$_GET['q'] = 'Hello';
+ob_start();
+require __DIR__ . '/../public/forum/search.php';
+$output = ob_get_clean();
+
+if (strpos($output, 'Hello World') !== false && strpos($output, 'Another Topic') === false) {
+    echo "Forum search works\n";
+} else {
+    echo "Forum search failed\n";
+    exit(1);
+}
+
+unlink($dbFile);


### PR DESCRIPTION
## Summary
- add `searchTopics` helper to query topics and post bodies
- add forum search page with search form on forum index
- style forum search input
- cover search with integration test

## Testing
- `php tests/forum_search.php`
- `php tests/forum_delete.php`
- `php tests/forum_permissions.php`
- `php tests/forum_public.php`


------
https://chatgpt.com/codex/tasks/task_e_689525125bbc8321bfaa28103c368458