### PR TITLE
Improve accessibility and add dark mode

### DIFF
--- a/public/addfavorite.php
+++ b/public/addfavorite.php
@@ -18,7 +18,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST["submit"])) {
 ?>
 <?php require("header.php"); ?>
 <div class="simple-container">
-  <h1><img src="static/icons/award_star_add.png" class="icon" aria-hidden="true" loading="lazy" alt=""> Add Favorite</h1>
+  <h1><img src="static/icons/award_star_add.png" class="icon" aria-hidden="true" loading="lazy" alt="Add to favorites icon"> Add Favorite</h1>
       <p>Do you want to add this user to your Favorites?</p>
     <form method="post">
       <button type="submit" name="submit">Add to Favorites</button>

--- a/public/blog/category.php
+++ b/public/blog/category.php
@@ -19,13 +19,13 @@ $blogEntries = fetchBlogEntriesByCategory($categoryId);
       <ul>
         <!--
         <li><b><a href="/"><img src="/static/icons/asterisk_yellow.png" class="icon" aria-hidden="true" loading="lazy"
-                alt=""> Top Entries</a></b></li>
+                alt="Featured entries icon"> Top Entries</a></b></li>
 -->
-        <li><a href="/blog/"><img src="/static/icons/clock.png" class="icon" aria-hidden="true" loading="lazy" alt="">
+        <li><a href="/blog/"><img src="/static/icons/clock.png" class="icon" aria-hidden="true" loading="lazy" alt="Recent entries icon">
             <b>Recent Entries</b></a></li>
             <!--
         <li><a href="/subscriptions"><img src="/static/icons/world.png" class="icon" aria-hidden="true" loading="lazy"
-              alt=""> Subscriptions</a></li>
+              alt="Subscriptions icon"> Subscriptions</a></li>
 -->
       </ul>
       <b>Categories:</b>

--- a/public/blog/entry.php
+++ b/public/blog/entry.php
@@ -69,11 +69,11 @@ $commentType = 'blog';
                 </p>
                 <p class="links">
                     <a href="user.php?id=<?= $authorId ?>">
-                        <img src="../static/icons/script.png" class="icon" aria-hidden="true" loading="lazy" alt=""> <span
+                        <img src="../static/icons/script.png" class="icon" aria-hidden="true" loading="lazy" alt="Blog icon"> <span
                             class="m-hide">View</span> Blog
                     </a>
                     <a href="https://<?= DOMAIN_NAME ?>../profile.php?id=<?= $authorId ?>">
-                        <img src="../static/icons/user.png" class="icon" aria-hidden="true" loading="lazy" alt=""> <span
+                        <img src="../static/icons/user.png" class="icon" aria-hidden="true" loading="lazy" alt="User profile icon"> <span
                             class="m-hide">View</span> Profile
                     </a>
 

--- a/public/blog/index.php
+++ b/public/blog/index.php
@@ -19,13 +19,13 @@ $highlightedEntry = 11;
       <ul>
         <!--
         <li><b><a href="/"><img src="/static/icons/asterisk_yellow.png" class="icon" aria-hidden="true" loading="lazy"
-                alt=""> Top Entries</a></b></li>
+                alt="Featured entries icon"> Top Entries</a></b></li>
 -->
-        <li><a href="/blog/"><img src="/static/icons/clock.png" class="icon" aria-hidden="true" loading="lazy" alt="">
+        <li><a href="/blog/"><img src="/static/icons/clock.png" class="icon" aria-hidden="true" loading="lazy" alt="Recent entries icon">
             <b>Recent Entries</b></a></li>
             <!--
         <li><a href="/subscriptions"><img src="/static/icons/world.png" class="icon" aria-hidden="true" loading="lazy"
-              alt=""> Subscriptions</a></li>
+              alt="Subscriptions icon"> Subscriptions</a></li>
 -->
       </ul>
       <b>Categories:</b>

--- a/public/browse.php
+++ b/public/browse.php
@@ -34,14 +34,14 @@ function isFilterActive($filter, $friends = null) {
     Filter:
     <a href="browse.php" class="<?= isFilterActive('') ? 'filter-active' : '' ?>">
     <?php if (isFilterActive('')): ?>
-        <img src="static/icons/tick.png" class="icon" aria-hidden="true" loading="lazy" alt="">
+        <img src="static/icons/tick.png" class="icon" aria-hidden="true" loading="lazy" alt="Selected filter">
     <?php endif; ?>
     All Users
 </a>
 |
 <a href="browse.php?view=new" class="<?= isFilterActive('new') ? 'filter-active' : '' ?>">
     <?php if (isFilterActive('new')): ?>
-        <img src="static/icons/tick.png" class="icon" aria-hidden="true" loading="lazy" alt="">
+        <img src="static/icons/tick.png" class="icon" aria-hidden="true" loading="lazy" alt="Selected filter">
     <?php endif; ?>
     New People
 </a>
@@ -50,14 +50,14 @@ function isFilterActive($filter, $friends = null) {
     Friends:
     <a href="browse.php?view=active" class="<?= isFilterActive('') ? 'filter-active' : '' ?>">
         <?php if (!isset($_GET['friends'])): ?>
-            <img src="static/icons/tick.png" class="icon" aria-hidden="true" loading="lazy" alt="">
+            <img src="static/icons/tick.png" class="icon" aria-hidden="true" loading="lazy" alt="Selected filter">
         <?php endif; ?>
         Include Friends
     </a>
     |
     <a href="browse.php?view=active&friends=no" class="<?= isFilterActive('active', 'no') ? 'filter-active' : '' ?>">
         <?php if (isFilterActive('active', 'no')): ?>
-            <img src="static/icons/tick.png" class="icon" aria-hidden="true" loading="lazy" alt="">
+            <img src="static/icons/tick.png" class="icon" aria-hidden="true" loading="lazy" alt="Selected filter">
         <?php endif; ?>
         Exclude Friends
     </a>

--- a/public/bulletins/bulletin.php
+++ b/public/bulletins/bulletin.php
@@ -66,11 +66,11 @@ $commentType = 'bulletin';
                 </p>
                 <p class="links">
                     <a href="userbulletins.php?id=<?= $authorId ?>">
-                        <img src="../static/icons/text_list_bullets.png" class="icon" aria-hidden="true" loading="lazy" alt=""> <span
+                        <img src="../static/icons/text_list_bullets.png" class="icon" aria-hidden="true" loading="lazy" alt="Bulletins icon"> <span
                             class="m-hide">View</span> Bulletins
                     </a>
                     <a href="https://<?= DOMAIN_NAME ?>../profile.php?id=<?= $authorId ?>">
-                        <img src="../static/icons/user.png" class="icon" aria-hidden="true" loading="lazy" alt=""> <span
+                        <img src="../static/icons/user.png" class="icon" aria-hidden="true" loading="lazy" alt="User profile icon"> <span
                             class="m-hide">View</span> Profile
                     </a>
 

--- a/public/favorites.php
+++ b/public/favorites.php
@@ -14,7 +14,7 @@ $favorites =json_decode($favoritesArray, true);
 <?php require("header.php"); ?>
 <div class="simple-container">
   <h1>Your Favorites</h1>
-  <p class="info">Click on <b><img src="static/icons/award_star_add.png" class="icon" aria-hidden="true" loading="lazy" alt=""> Add to Favorites</b> on any profile to add a user to this list.</p>
+  <p class="info">Click on <b><img src="static/icons/award_star_add.png" class="icon" aria-hidden="true" loading="lazy" alt="Add to favorites icon"> Add to Favorites</b> on any profile to add a user to this list.</p>
   <div class="new-people">
     <div class="top">
       <h4>Favorite Users</h4>

--- a/public/forum/index.php
+++ b/public/forum/index.php
@@ -13,7 +13,7 @@ $categories = forum_get_categories();
     <h1>Forums</h1>
     <form class="forum-search" action="search.php" method="get">
         <input type="text" name="q">
-        <button type="submit">Search</button>
+        <button type="submit" aria-label="Search forums" role="button">Search</button>
     </form>
     <?php foreach ($categories as $cat): ?>
         <h2><?= htmlspecialchars($cat['name']) ?></h2>

--- a/public/forum/post.php
+++ b/public/forum/post.php
@@ -88,11 +88,11 @@ $pageCSS = "../static/css/forum.css";
     <div class="mod-actions">
         <form method="post" style="display:inline">
             <input type="hidden" name="action" value="<?= $topic['locked'] ? 'unlock' : 'lock' ?>">
-            <button type="submit"><?= $topic['locked'] ? 'Unlock' : 'Lock' ?></button>
+            <button type="submit" aria-label="<?= $topic['locked'] ? 'Unlock topic' : 'Lock topic' ?>" role="button"><?= $topic['locked'] ? 'Unlock' : 'Lock' ?></button>
         </form>
         <form method="post" style="display:inline">
             <input type="hidden" name="action" value="<?= $topic['sticky'] ? 'unsticky' : 'sticky' ?>">
-            <button type="submit"><?= $topic['sticky'] ? 'Unsticky' : 'Sticky' ?></button>
+            <button type="submit" aria-label="<?= $topic['sticky'] ? 'Unsticky topic' : 'Sticky topic' ?>" role="button"><?= $topic['sticky'] ? 'Unsticky' : 'Sticky' ?></button>
         </form>
     </div>
     <?php endif; ?>
@@ -112,25 +112,25 @@ $pageCSS = "../static/css/forum.css";
         <tr class="forum-post">
             <td class="avatar-cell">
                 <div class="avatar-wrapper">
-                    <a href="<?= $profileLink ?>"><img class="avatar" src="<?= htmlspecialchars($avatarPath) ?>" alt="<?= htmlspecialchars($user['username']) ?>'s avatar" loading="lazy"></a>
+                    <a href="<?= $profileLink ?>" aria-label="View <?= htmlspecialchars($user['username']) ?>'s profile" role="link"><img class="avatar" src="<?= htmlspecialchars($avatarPath) ?>" alt="<?= htmlspecialchars($user['username']) ?>'s avatar" loading="lazy"></a>
                     <?= $badge ?>
                 </div>
             </td>
             <td class="post-body">
-                <p><strong><a class="username" href="<?= $profileLink ?>"><?= htmlspecialchars($user['username']) ?></a></strong> <?= htmlspecialchars($post['created_at']) ?></p>
+                <p><strong><a class="username" href="<?= $profileLink ?>" aria-label="View <?= htmlspecialchars($user['username']) ?>'s profile" role="link"><?= htmlspecialchars($user['username']) ?></a></strong> <?= htmlspecialchars($post['created_at']) ?></p>
                 <?php if ($post['deleted']): ?>
                     <p><em>Post deleted.</em></p>
                 <?php else: ?>
                     <p><?= nl2br(replaceBBcodes($post['body'])) ?></p>
                     <?php if ($can_post): ?>
-                        <a href="post.php?id=<?= $topicId ?>&quote=<?= $post['id'] ?>">Quote</a>
+                        <a href="post.php?id=<?= $topicId ?>&quote=<?= $post['id'] ?>" aria-label="Quote this post" role="link">Quote</a>
                     <?php endif; ?>
                 <?php endif; ?>
                 <?php if ($can_moderate): ?>
                     <form method="post" style="display:inline">
                         <input type="hidden" name="post_id" value="<?= $post['id'] ?>">
                         <input type="hidden" name="action" value="<?= $post['deleted'] ? 'restore_post' : 'delete_post' ?>">
-                        <button type="submit"><?= $post['deleted'] ? 'Restore' : 'Delete' ?></button>
+                        <button type="submit" aria-label="<?= $post['deleted'] ? 'Restore post' : 'Delete post' ?>" role="button"><?= $post['deleted'] ? 'Restore' : 'Delete' ?></button>
                     </form>
                 <?php endif; ?>
             </td>
@@ -144,8 +144,8 @@ $pageCSS = "../static/css/forum.css";
 
     <?php if (!$topic['locked'] && $can_post): ?>
     <form method="post">
-        <textarea name="body"><?= htmlspecialchars($prefill) ?></textarea>
-        <button type="submit">Post</button>
+        <textarea name="body" aria-label="Post message"><?= htmlspecialchars($prefill) ?></textarea>
+        <button type="submit" aria-label="Submit reply" role="button">Post</button>
     </form>
     <?php elseif ($topic['locked']): ?>
         <p>This topic is locked.</p>

--- a/public/forum/search.php
+++ b/public/forum/search.php
@@ -16,13 +16,13 @@ if ($query !== '') {
     <h1>Forum Search</h1>
     <form class="forum-search" action="search.php" method="get">
         <input type="text" name="q" value="<?= htmlspecialchars($query) ?>">
-        <button type="submit">Search</button>
+        <button type="submit" aria-label="Search forums" role="button">Search</button>
     </form>
     <?php if ($query !== ''): ?>
         <?php if (!empty($results)): ?>
             <ul>
                 <?php foreach ($results as $topic): ?>
-                    <li><a href="topic.php?id=<?= $topic['id'] ?>"><?= htmlspecialchars($topic['title']) ?></a></li>
+                    <li><a href="topic.php?id=<?= $topic['id'] ?>" aria-label="View topic <?= htmlspecialchars($topic['title']) ?>" role="link"><?= htmlspecialchars($topic['title']) ?></a></li>
                 <?php endforeach; ?>
             </ul>
         <?php else: ?>

--- a/public/forum/settings.php
+++ b/public/forum/settings.php
@@ -53,7 +53,7 @@ require("../header.php");
                 <input type="text" name="text_color" value="<?= htmlspecialchars($settings['text_color'] ?? '') ?>" placeholder="#000000">
             </label>
         </p>
-        <p><input type="submit" value="Save"></p>
+        <p><button type="submit" aria-label="Save forum settings" role="button">Save</button></p>
     </form>
 </div>
 <?php require("../footer.php"); ?>

--- a/public/forum/topic.php
+++ b/public/forum/topic.php
@@ -66,8 +66,8 @@ $pageCSS = "../static/css/forum.css";
         <?php foreach ($topics as $t): ?>
         <?php $linkId = $t['moved_to'] ? $t['moved_to'] : $t['id']; ?>
         <tr>
-            <td class="icon-cell"><img src="../static/icons/comment.png" alt="Topic" loading="lazy"></td>
-            <td><a href="post.php?id=<?= $linkId ?>"><?= htmlspecialchars($t['title']) ?></a></td>
+            <td class="icon-cell"><img src="../static/icons/comment.png" alt="Topic icon" loading="lazy"></td>
+            <td><a href="post.php?id=<?= $linkId ?>" aria-label="View topic <?= htmlspecialchars($t['title']) ?>" role="link"><?= htmlspecialchars($t['title']) ?></a></td>
             <td><?= (int)$t['posts'] ?></td>
             <td><?= htmlspecialchars($t['last_post']) ?></td>
             <?php if ($can_moderate): ?>
@@ -75,12 +75,12 @@ $pageCSS = "../static/css/forum.css";
                 <form method="post" style="display:inline">
                     <input type="hidden" name="topic_id" value="<?= $t['id'] ?>">
                     <input type="hidden" name="action" value="<?= $t['locked'] ? 'unlock' : 'lock' ?>">
-                    <button type="submit"><?= $t['locked'] ? 'Unlock' : 'Lock' ?></button>
+                    <button type="submit" aria-label="<?= $t['locked'] ? 'Unlock topic' : 'Lock topic' ?>" role="button"><?= $t['locked'] ? 'Unlock' : 'Lock' ?></button>
                 </form>
                 <form method="post" style="display:inline">
                     <input type="hidden" name="topic_id" value="<?= $t['id'] ?>">
                     <input type="hidden" name="action" value="<?= $t['sticky'] ? 'unsticky' : 'sticky' ?>">
-                    <button type="submit"><?= $t['sticky'] ? 'Unsticky' : 'Sticky' ?></button>
+                    <button type="submit" aria-label="<?= $t['sticky'] ? 'Unsticky topic' : 'Sticky topic' ?>" role="button"><?= $t['sticky'] ? 'Unsticky' : 'Sticky' ?></button>
                 </form>
             </td>
             <?php endif; ?>
@@ -95,9 +95,9 @@ $pageCSS = "../static/css/forum.css";
     <?php if ($can_post): ?>
     <h2>New Topic</h2>
     <form method="post">
-        <input type="text" name="title" placeholder="Title">
-        <textarea name="body"></textarea>
-        <button type="submit">Post</button>
+        <input type="text" name="title" placeholder="Title" aria-label="Topic title">
+        <textarea name="body" aria-label="Topic message"></textarea>
+        <button type="submit" aria-label="Post new topic" role="button">Post</button>
     </form>
     <?php endif; ?>
 </div>

--- a/public/layouts/preview.php
+++ b/public/layouts/preview.php
@@ -96,13 +96,13 @@
                                         <a href="friends.php?action=add&id=1"
                                             rel="nofollow">
                                             <img src="static/icons/add.png" class="icon" aria-hidden="true" loading="lazy"
-                                                alt=""> Add to Friends
+                                                alt="Add friend icon"> Add to Friends
                                         </a>
                                     </div>
                                     <div class="f-col">
                                         <a href="#" rel="nofollow">
                                             <img src="static/icons/award_star_add.png" class="icon" aria-hidden="true"
-                                                loading="lazy" alt=""> Add to Favorites
+                                                loading="lazy" alt="Add to favorites icon"> Add to Favorites
                                         </a>
                                     </div>
                                 </div>
@@ -110,13 +110,13 @@
                                     <div class="f-col">
                                         <a href="#" rel="nofollow">
                                             <img src="static/icons/comment.png" class="icon" aria-hidden="true"
-                                                loading="lazy" alt=""> Send Message
+                                                loading="lazy" alt="Send message icon"> Send Message
                                         </a>
                                     </div>
                                     <div class="f-col">
                                         <a href="#" rel="nofollow">
                                             <img src="static/icons/arrow_right.png" class="icon" aria-hidden="true"
-                                                loading="lazy" alt=""> Forward to Friend
+                                                loading="lazy" alt="Forward to friend icon"> Forward to Friend
                                         </a>
                                     </div>
                                 </div>
@@ -124,13 +124,13 @@
                                     <div class="f-col">
                                         <a href="#" rel="nofollow">
                                             <img src="static/icons/email.png" class="icon" aria-hidden="true" loading="lazy"
-                                                alt=""> Instant Message
+                                                alt="Instant message icon"> Instant Message
                                         </a>
                                     </div>
                                     <div class="f-col">
                                         <a href="#" rel="nofollow">
                                             <img src="static/icons/exclamation.png" class="icon" aria-hidden="true"
-                                                loading="lazy" alt=""> Block User
+                                                loading="lazy" alt="Block user icon"> Block User
                                         </a>
                                     </div>
                                 </div>
@@ -138,13 +138,13 @@
                                     <div class="f-col">
                                         <a href="#">
                                             <img src="static/icons/group_add.png" class="icon" aria-hidden="true"
-                                                loading="lazy" alt=""> Add to Group
+                                                loading="lazy" alt="Add to group icon"> Add to Group
                                         </a>
                                     </div>
                                     <div class="f-col">
                                         <a href="#" rel="nofollow">
                                             <img src="static/icons/flag_red.png" class="icon" aria-hidden="true"
-                                                loading="lazy" alt=""> Report User
+                                                loading="lazy" alt="Report user icon"> Report User
                                         </a>
                                     </div>
                                 </div>
@@ -305,8 +305,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=28"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>
@@ -337,8 +337,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=24"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>
@@ -369,8 +369,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=23"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>
@@ -401,8 +401,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=22"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>
@@ -433,8 +433,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=21"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>
@@ -465,8 +465,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=20"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>
@@ -497,8 +497,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=19"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>
@@ -529,8 +529,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=18"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>
@@ -561,8 +561,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=17"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>
@@ -593,8 +593,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=16"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>
@@ -625,8 +625,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=15"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>
@@ -657,8 +657,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=14"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>
@@ -689,8 +689,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=13"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>
@@ -721,8 +721,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=12"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>
@@ -753,8 +753,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=11"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>
@@ -785,8 +785,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=10"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>
@@ -817,8 +817,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=9"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>
@@ -849,8 +849,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=8"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>
@@ -881,8 +881,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=7"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>
@@ -913,8 +913,8 @@
                                                 <p class="report">
                                                     <a href="/report?type=comment&id=6"
                                                         rel="nofollow">
-                                                        <img src="/static/icons/flag_red.png"
-                                                            class="icon" aria-hidden="true" loading="lazy" alt=""> Report
+                                                        <img src="/static/icons/flag_red.png" alt="Red flag icon"
+                                                            class="icon" aria-hidden="true" loading="lazy" alt="Report user icon"> Report
                                                         Comment
                                                     </a>
                                                 </p>

--- a/public/profile.php
+++ b/public/profile.php
@@ -257,26 +257,26 @@ $statusInfo = fetchUserStatus($profileId);
                                         <a href="unfriend.php?action=add&id=<?= htmlspecialchars($profileId); ?>"
                                             rel="nofollow">
                                             <img src="static/icons/delete.png" class="icon" aria-hidden="true" loading="lazy"
-                                                alt=""> Remove Friend
+                                                alt="Remove friend icon"> Remove Friend
                                         </a>
                                         <?php elseif ($isPendingFriend): ?>
                                         <a href="requests.php"
                                             rel="nofollow">
                                             <img src="static/icons/hourglass.png" class="icon" aria-hidden="true" loading="lazy"
-                                                alt=""> Pending Request
+                                                alt="Pending request icon"> Pending Request
                                         </a>
                                         <?php else: ?>
                                         <a href="friends.php?action=add&id=<?= htmlspecialchars($profileId); ?>"
                                             rel="nofollow">
                                             <img src="static/icons/add.png" class="icon" aria-hidden="true" loading="lazy"
-                                                alt=""> Add to Friends
+                                                alt="Add friend icon"> Add to Friends
                                         </a>
                                         <?php endif; ?>
                                     </div>
                                     <div class="f-col">
                                         <a href="addfavorite.php?id=<?= $profileId ?>" rel="nofollow">
                                             <img src="static/icons/award_star_add.png" class="icon" aria-hidden="true"
-                                                loading="lazy" alt=""> Add to Favorites
+                                                loading="lazy" alt="Add to favorites icon"> Add to Favorites
                                         </a>
                                     </div>
                                 </div>
@@ -284,13 +284,13 @@ $statusInfo = fetchUserStatus($profileId);
                                     <div class="f-col">
                                         <a href="#" rel="nofollow">
                                             <img src="static/icons/comment.png" class="icon" aria-hidden="true"
-                                                loading="lazy" alt=""> Send Message
+                                                loading="lazy" alt="Send message icon"> Send Message
                                         </a>
                                     </div>
                                     <div class="f-col">
                                         <a href="#" rel="nofollow">
                                             <img src="static/icons/arrow_right.png" class="icon" aria-hidden="true"
-                                                loading="lazy" alt=""> Forward to Friend
+                                                loading="lazy" alt="Forward to friend icon"> Forward to Friend
                                         </a>
                                     </div>
                                 </div>
@@ -298,13 +298,13 @@ $statusInfo = fetchUserStatus($profileId);
                                     <div class="f-col">
                                         <a href="#" rel="nofollow">
                                             <img src="static/icons/email.png" class="icon" aria-hidden="true" loading="lazy"
-                                                alt=""> Instant Message
+                                                alt="Instant message icon"> Instant Message
                                         </a>
                                     </div>
                                     <div class="f-col">
                                         <a href="#" rel="nofollow">
                                             <img src="static/icons/exclamation.png" class="icon" aria-hidden="true"
-                                                loading="lazy" alt=""> Block User
+                                                loading="lazy" alt="Block user icon"> Block User
                                         </a>
                                     </div>
                                 </div>
@@ -312,13 +312,13 @@ $statusInfo = fetchUserStatus($profileId);
                                     <div class="f-col">
                                         <a href="#">
                                             <img src="static/icons/group_add.png" class="icon" aria-hidden="true"
-                                                loading="lazy" alt=""> Add to Group
+                                                loading="lazy" alt="Add to group icon"> Add to Group
                                         </a>
                                     </div>
                                     <div class="f-col">
                                         <a href="#" rel="nofollow">
                                             <img src="static/icons/flag_red.png" class="icon" aria-hidden="true"
-                                                loading="lazy" alt=""> Report User
+                                                loading="lazy" alt="Report user icon"> Report User
                                         </a>
                                     </div>
                                 </div>

--- a/public/settings.php
+++ b/public/settings.php
@@ -117,6 +117,15 @@ if (isset($_POST['password-old']) && isset($_POST['password-new']) && isset($_PO
       </div>
     </div>
 
+    <div class="setting-section">
+      <div class="heading">
+        <h4>Display Options</h4>
+      </div>
+      <div class="inner">
+        <label><input type="checkbox" id="accessibilityToggle" aria-label="Enable dark mode and larger text"> Dark mode / larger text</label>
+      </div>
+    </div>
+
     <!-- 
     <div class="setting-section">
       <div class="heading">
@@ -144,6 +153,20 @@ if (isset($_POST['password-old']) && isset($_POST['password-new']) && isset($_PO
           -->
     <button type="submit" name="submit">Save All</button>
   </form>
+  <script>
+    const toggle=document.getElementById('accessibilityToggle');
+    const body=document.body;
+    const stored=localStorage.getItem('accessibilityMode')==='true';
+    if(stored){
+      body.classList.add('dark-mode','large-text');
+      toggle.checked=true;
+    }
+    toggle.addEventListener('change',()=>{
+      body.classList.toggle('dark-mode',toggle.checked);
+      body.classList.toggle('large-text',toggle.checked);
+      localStorage.setItem('accessibilityMode',toggle.checked);
+    });
+  </script>
   <br>
   <h4 style="margin-bottom: 5px;">More Options</h4>
   <!--

--- a/public/static/css/base.css
+++ b/public/static/css/base.css
@@ -50,8 +50,9 @@ html, body{
 
 body {
   font-family: verdana, arial, sans-serif, helvetica;
-  background-color: #e5e5e5;
-  /*font-size: 10pt;*/
+  background-color: #ffffff;
+  color: #000000;
+  font-size: 16px;
   margin: 0;
 }
 
@@ -69,13 +70,32 @@ a:hover {
 }
 
 h2 {
-  font-size: 9pt;
+  font-size: 1.25rem;
   margin: 0;
   font-weight: bold;
 }
 
 p {
   line-height: 1.3;
+}
+
+a:focus,
+button:focus {
+  outline: 3px solid var(--dark-orange);
+  outline-offset: 2px;
+}
+
+body.dark-mode {
+  background-color: #111111;
+  color: #f5f5f5;
+}
+
+body.dark-mode a {
+  color: #93c5fd;
+}
+
+body.large-text {
+  font-size: 20px;
 }
 
 /*

--- a/public/static/css/forum.css
+++ b/public/static/css/forum.css
@@ -3,12 +3,13 @@
 
 body {
     font-family: Verdana, Arial, sans-serif;
-    font-size: 10pt;
+    font-size: 12pt;
     background-color: var(--light-gray);
+    color: #000000;
     background-image: repeating-linear-gradient(
         45deg,
-        var(--even-lighter-blue) 0 20px,
-        var(--even-lighter-orange) 20px 40px
+        var(--lighter-blue) 0 20px,
+        var(--light-orange) 20px 40px
     );
 }
 
@@ -31,17 +32,17 @@ body {
 .post-table th,
 .post-table td {
     padding: 8px;
-    border: 1px solid var(--light-gray);
+    border: 1px solid var(--dark-gray);
 }
 
 .forum-table tr:nth-child(even),
 .post-table tr:nth-child(even) {
-    background-color: var(--even-lighter-blue);
+    background-color: var(--lighter-blue);
 }
 
 .forum-table tr:nth-child(odd),
 .post-table tr:nth-child(odd) {
-    background-color: var(--even-lighter-orange);
+    background-color: var(--light-orange);
 }
 
 /* Vintage thread icon */
@@ -102,4 +103,37 @@ body {
 .forum-search input[type="text"] {
     padding: 4px;
     border: 1px solid var(--light-gray);
+}
+
+a:focus,
+button:focus {
+    outline: 3px solid var(--darker-blue);
+    outline-offset: 2px;
+}
+
+body.dark-mode {
+    background-color: #1a1a1a;
+    color: #e5e5e5;
+    background-image: none;
+}
+
+body.dark-mode .forum-header,
+body.dark-mode .forum-post {
+    background-image: none;
+    background-color: #333333;
+    color: #ffffff;
+}
+
+body.dark-mode .forum-table tr:nth-child(even),
+body.dark-mode .post-table tr:nth-child(even) {
+    background-color: #2d3748;
+}
+
+body.dark-mode .forum-table tr:nth-child(odd),
+body.dark-mode .post-table tr:nth-child(odd) {
+    background-color: #1f2937;
+}
+
+body.large-text {
+    font-size: 16pt;
 }


### PR DESCRIPTION
## Summary
- increase base and forum font sizes and color contrast, add focus outlines and dark/large text classes
- add aria labels and roles to forum buttons and links, and provide alt text for icons
- add settings toggle for dark mode with larger text

## Testing
- `php tests/forum_public.php`
- `php tests/forum_permissions.php`
- `php tests/forum_delete.php`
- `php tests/forum_search.php`
- `php tests/forum_notifications.php`


------
https://chatgpt.com/codex/tasks/task_e_68952df348048321993785ae1d755ff5