### PR TITLE
Add moderator action logging

### DIFF
--- a/core/forum/mod_log.php
+++ b/core/forum/mod_log.php
@@ -1,0 +1,12 @@
+<?php
+function logModAction(int $moderator_id, string $action, string $target_type, int $target_id): void {
+    global $conn;
+    $stmt = $conn->prepare('INSERT INTO mod_log (moderator_id, action, target_type, target_id, timestamp) VALUES (:mid, :action, :ttype, :tid, CURRENT_TIMESTAMP)');
+    $stmt->execute([
+        ':mid' => $moderator_id,
+        ':action' => $action,
+        ':ttype' => $target_type,
+        ':tid' => $target_id
+    ]);
+}
+?>

--- a/core/forum/post.php
+++ b/core/forum/post.php
@@ -3,6 +3,7 @@
 require_once(__DIR__ . '/topic.php');
 require_once(__DIR__ . '/../helper.php');
 require_once(__DIR__ . '/notifications.php');
+require_once(__DIR__ . '/mod_log.php');
 
 function forum_add_post(int $topic_id, int $user_id, string $body)
 {
@@ -67,6 +68,7 @@ function post_soft_delete(int $post_id, int $by_user_id): void
     $stmt = $conn->prepare('UPDATE forum_posts SET deleted = 1, deleted_by = :uid, deleted_at = NOW() WHERE id = :id');
     $stmt->execute([':id' => $post_id, ':uid' => $by_user_id]);
     forum_log_action("User {$by_user_id} deleted post {$post_id}");
+    logModAction($by_user_id, 'delete', 'post', $post_id);
 }
 
 function post_restore(int $post_id, int $by_user_id): void
@@ -75,6 +77,7 @@ function post_restore(int $post_id, int $by_user_id): void
     $stmt = $conn->prepare('UPDATE forum_posts SET deleted = 0, deleted_by = NULL, deleted_at = NULL WHERE id = :id');
     $stmt->execute([':id' => $post_id]);
     forum_log_action("User {$by_user_id} restored post {$post_id}");
+    logModAction($by_user_id, 'restore', 'post', $post_id);
 }
 
 function post_get_quote(int $post_id): ?array

--- a/core/forum/topic.php
+++ b/core/forum/topic.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once(__DIR__ . '/../helper.php');
+require_once(__DIR__ . '/mod_log.php');
 
 function forum_log_action(string $message): void {
     $logFile = __DIR__ . '/../../admin_logs.txt';
@@ -13,6 +14,7 @@ function topic_lock(int $topic_id, int $by_user_id): void {
     $stmt = $conn->prepare('UPDATE forum_topics SET locked = 1 WHERE id = :id');
     $stmt->execute([':id' => $topic_id]);
     forum_log_action("User {$by_user_id} locked topic {$topic_id}");
+    logModAction($by_user_id, 'lock', 'topic', $topic_id);
 }
 
 function topic_unlock(int $topic_id, int $by_user_id): void {
@@ -20,6 +22,7 @@ function topic_unlock(int $topic_id, int $by_user_id): void {
     $stmt = $conn->prepare('UPDATE forum_topics SET locked = 0 WHERE id = :id');
     $stmt->execute([':id' => $topic_id]);
     forum_log_action("User {$by_user_id} unlocked topic {$topic_id}");
+    logModAction($by_user_id, 'unlock', 'topic', $topic_id);
 }
 
 function topic_sticky(int $topic_id, int $by_user_id): void {
@@ -27,6 +30,7 @@ function topic_sticky(int $topic_id, int $by_user_id): void {
     $stmt = $conn->prepare('UPDATE forum_topics SET sticky = 1 WHERE id = :id');
     $stmt->execute([':id' => $topic_id]);
     forum_log_action("User {$by_user_id} stickied topic {$topic_id}");
+    logModAction($by_user_id, 'sticky', 'topic', $topic_id);
 }
 
 function topic_unsticky(int $topic_id, int $by_user_id): void {
@@ -34,6 +38,7 @@ function topic_unsticky(int $topic_id, int $by_user_id): void {
     $stmt = $conn->prepare('UPDATE forum_topics SET sticky = 0 WHERE id = :id');
     $stmt->execute([':id' => $topic_id]);
     forum_log_action("User {$by_user_id} unstickied topic {$topic_id}");
+    logModAction($by_user_id, 'unsticky', 'topic', $topic_id);
 }
 
 function topic_move(int $topic_id, int $new_forum_id, int $by_user_id): void {
@@ -61,6 +66,7 @@ function topic_move(int $topic_id, int $new_forum_id, int $by_user_id): void {
 
         $conn->commit();
         forum_log_action("User {$by_user_id} moved topic {$topic_id} from forum {$old_forum_id} to forum {$new_forum_id}");
+        logModAction($by_user_id, 'move', 'topic', $topic_id);
     } catch (Exception $e) {
         $conn->rollBack();
         throw $e;

--- a/public/forum/mod/log.php
+++ b/public/forum/mod/log.php
@@ -1,0 +1,53 @@
+<?php
+require("../../../core/conn.php");
+require_once("../../../core/settings.php");
+require_once("../../../core/forum/mod_check.php");
+
+forum_mod_check();
+
+$conditions = [];
+$params = [];
+if (!empty($_GET['moderator'])) {
+    $conditions[] = 'l.moderator_id = :mid';
+    $params[':mid'] = (int)$_GET['moderator'];
+}
+if (!empty($_GET['date'])) {
+    $conditions[] = 'DATE(l.timestamp) = :date';
+    $params[':date'] = $_GET['date'];
+}
+$sql = 'SELECT l.*, u.username FROM mod_log l JOIN users u ON l.moderator_id = u.id';
+if ($conditions) {
+    $sql .= ' WHERE ' . implode(' AND ', $conditions);
+}
+$sql .= ' ORDER BY l.timestamp DESC LIMIT 100';
+$stmt = $conn->prepare($sql);
+$stmt->execute($params);
+$logs = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+$pageCSS = "../../static/css/forum.css";
+?>
+<?php require("../../header.php"); ?>
+<div class="simple-container">
+    <h1>Moderator Log</h1>
+    <form method="get" style="margin-bottom:1em;">
+        <label>Moderator ID: <input type="text" name="moderator" value="<?= htmlspecialchars($_GET['moderator'] ?? '') ?>"></label>
+        <label>Date: <input type="date" name="date" value="<?= htmlspecialchars($_GET['date'] ?? '') ?>"></label>
+        <button type="submit">Filter</button>
+    </form>
+    <?php if (empty($logs)): ?>
+    <p>No log entries found.</p>
+    <?php else: ?>
+    <table class="forum-table">
+        <tr><th>Time</th><th>Moderator</th><th>Action</th><th>Target</th></tr>
+        <?php foreach ($logs as $log): ?>
+        <tr>
+            <td><?= htmlspecialchars($log['timestamp']) ?></td>
+            <td><?= htmlspecialchars($log['username']) ?></td>
+            <td><?= htmlspecialchars($log['action']) ?></td>
+            <td><?= htmlspecialchars($log['target_type'] . ' #' . $log['target_id']) ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </table>
+    <?php endif; ?>
+</div>
+<?php require("../../footer.php"); ?>

--- a/schema.sql
+++ b/schema.sql
@@ -366,3 +366,18 @@ CREATE TABLE IF NOT EXISTS `notifications` (
   FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
   FOREIGN KEY (`post_id`) REFERENCES `forum_posts` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- --------------------------------------------------------
+--
+-- Table structure for table `mod_log`
+--
+CREATE TABLE IF NOT EXISTS `mod_log` (
+  `id` int(11) NOT NULL auto_increment,
+  `moderator_id` int(11) NOT NULL,
+  `action` varchar(255) NOT NULL,
+  `target_type` varchar(255) NOT NULL,
+  `target_id` int(11) NOT NULL,
+  `timestamp` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  FOREIGN KEY (`moderator_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/tests/forum_mod_log.php
+++ b/tests/forum_mod_log.php
@@ -1,0 +1,39 @@
+<?php
+// Test for moderator logging on topic lock action
+require_once __DIR__ . '/../core/forum/topic.php';
+require_once __DIR__ . '/../core/forum/mod_log.php';
+
+session_start();
+
+$dbFile = __DIR__ . '/forum_mod_log.db';
+@unlink($dbFile);
+$dsn = 'sqlite:' . $dbFile;
+putenv('DB_DSN=' . $dsn);
+
+$conn = new PDO($dsn);
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$conn->sqliteCreateFunction('NOW', function() { return date('Y-m-d H:i:s'); });
+$conn->exec('CREATE TABLE forum_topics (id INTEGER PRIMARY KEY AUTOINCREMENT, forum_id INTEGER, title TEXT, locked INTEGER DEFAULT 0, sticky INTEGER DEFAULT 0, moved_to INTEGER DEFAULT NULL)');
+$conn->exec('CREATE TABLE mod_log (id INTEGER PRIMARY KEY AUTOINCREMENT, moderator_id INTEGER, action TEXT, target_type TEXT, target_id INTEGER, timestamp TEXT DEFAULT CURRENT_TIMESTAMP)');
+
+global $conn;
+
+// seed topic
+$conn->exec("INSERT INTO forum_topics (forum_id, title, locked, sticky) VALUES (1, 'Test', 0, 0)");
+
+// perform action
+
+echo "Lock topic...\n";
+topic_lock(1, 42);
+
+$count = $conn->query("SELECT COUNT(*) FROM mod_log WHERE moderator_id = 42 AND action = 'lock' AND target_type = 'topic' AND target_id = 1")->fetchColumn();
+if ((int)$count === 1) {
+    echo "Log entry recorded\n";
+} else {
+    echo "Log entry missing\n";
+    unlink($dbFile);
+    exit(1);
+}
+
+unlink($dbFile);
+?>

--- a/tests/forum_posts.php
+++ b/tests/forum_posts.php
@@ -20,6 +20,7 @@ $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $conn->sqliteCreateFunction('NOW', function() { return date('Y-m-d H:i:s'); });
 $conn->exec('CREATE TABLE forum_topics (id INTEGER PRIMARY KEY AUTOINCREMENT, forum_id INTEGER, title TEXT, locked INTEGER DEFAULT 0, sticky INTEGER DEFAULT 0, moved_to INTEGER DEFAULT NULL)');
 $conn->exec('CREATE TABLE forum_posts (id INTEGER PRIMARY KEY AUTOINCREMENT, topic_id INTEGER, user_id INTEGER, body TEXT, created_at TEXT DEFAULT CURRENT_TIMESTAMP, deleted INTEGER DEFAULT 0, deleted_by INTEGER, deleted_at TEXT)');
+$conn->exec('CREATE TABLE mod_log (id INTEGER PRIMARY KEY AUTOINCREMENT, moderator_id INTEGER, action TEXT, target_type TEXT, target_id INTEGER, timestamp TEXT DEFAULT CURRENT_TIMESTAMP)');
 $conn->exec('CREATE TABLE forum_permissions (forum_id INTEGER, role TEXT, can_view INTEGER, can_post INTEGER, can_moderate INTEGER)');
 $conn->exec('CREATE TABLE forum_moderators (forum_id INTEGER, user_id INTEGER)');
 $conn->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT)');

--- a/tests/forum_topics.php
+++ b/tests/forum_topics.php
@@ -19,6 +19,7 @@ $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $conn->sqliteCreateFunction('NOW', function() { return date('Y-m-d H:i:s'); });
 $conn->exec('CREATE TABLE forum_topics (id INTEGER PRIMARY KEY AUTOINCREMENT, forum_id INTEGER, title TEXT, locked INTEGER DEFAULT 0, sticky INTEGER DEFAULT 0, moved_to INTEGER DEFAULT NULL)');
 $conn->exec('CREATE TABLE forum_posts (id INTEGER PRIMARY KEY AUTOINCREMENT, topic_id INTEGER, user_id INTEGER, body TEXT, created_at TEXT DEFAULT CURRENT_TIMESTAMP, deleted INTEGER DEFAULT 0, deleted_by INTEGER, deleted_at TEXT)');
+$conn->exec('CREATE TABLE mod_log (id INTEGER PRIMARY KEY AUTOINCREMENT, moderator_id INTEGER, action TEXT, target_type TEXT, target_id INTEGER, timestamp TEXT DEFAULT CURRENT_TIMESTAMP)');
 $conn->exec('CREATE TABLE forum_permissions (forum_id INTEGER, role TEXT, can_view INTEGER, can_post INTEGER, can_moderate INTEGER)');
 $conn->exec('CREATE TABLE forum_moderators (forum_id INTEGER, user_id INTEGER)');
 $conn->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT)');


### PR DESCRIPTION
## Summary
- Add `mod_log` table and logging helper
- Record moderator actions for posts and topics
- Provide moderator log viewer and tests

## Testing
- `php tests/forum_mod_log.php`
- `php tests/forum_posts.php`
- `php tests/forum_topics.php`


------
https://chatgpt.com/codex/tasks/task_e_689538cfd47c8321b0ae8d9801499243