### PR TITLE
Add user ban system and enforce in login

### DIFF
--- a/admin/login.php
+++ b/admin/login.php
@@ -11,19 +11,22 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['action'])) {
 
         if ($_POST['action'] == 'login') {
             // Prepare SQL statement for login
-            $stmt = $conn->prepare("SELECT id, username, password, rank FROM users WHERE email = ?");
+            $stmt = $conn->prepare("SELECT id, username, password, rank, banned_until FROM users WHERE email = ?");
             $stmt->execute(array($email));
             $user = $stmt->fetch(PDO::FETCH_ASSOC);
 
             $isAdmin = ($user['id'] == $adminUser);
 
-            if (($user && password_verify($password, $user['password'])) && $isAdmin) {
+            $notBanned = (empty($user['banned_until']) || strtotime($user['banned_until']) <= time());
+            if (($user && password_verify($password, $user['password']) && $notBanned) && $isAdmin) {
                 $_SESSION['user'] = $user['username'];
                 $_SESSION['userId'] = $user['id'];
                 $_SESSION['rank'] = $user['rank'];
 
                 header("Location: index.php");
                 exit;
+            } elseif ($user && !$notBanned) {
+                echo '<p>Account banned until ' . htmlspecialchars($user['banned_until']) . '</p><hr>';
             } else {
                 echo '<p>Login information doesn\'t exist, incorrect password, or user does not have proper permission.</p><hr>';
             }

--- a/anyspace.sql
+++ b/anyspace.sql
@@ -149,6 +149,7 @@ CREATE TABLE IF NOT EXISTS `users` (
   `date` datetime NOT NULL,
   `lastactive` datetime NOT NULL,
   `lastlogon` datetime NOT NULL,
+  `banned_until` datetime DEFAULT NULL,
   `bio` varchar(500) NOT NULL default '',
   `interests` varchar(500) NOT NULL default ' ',
   `css` blob NOT NULL,

--- a/core/helper.php
+++ b/core/helper.php
@@ -4,6 +4,14 @@ function login_check() {
         header("Location: /login.php");
         exit;
     }
+
+    require_once __DIR__ . '/users/user.php';
+    if (isset($_SESSION['userId']) && isUserBanned($_SESSION['userId'])) {
+        session_unset();
+        session_destroy();
+        header("Location: /login.php?msg=" . urlencode('Account banned'));
+        exit;
+    }
 }
 
 function admin_only() {

--- a/core/users/ban.php
+++ b/core/users/ban.php
@@ -1,0 +1,27 @@
+<?php
+require_once __DIR__ . '/../forum/mod_log.php';
+
+function banUser(int $user_id, string $until): void {
+    global $conn;
+    $stmt = $conn->prepare('UPDATE users SET banned_until = :until WHERE id = :id');
+    $stmt->execute([
+        ':until' => $until,
+        ':id' => $user_id
+    ]);
+
+    $mid = $_SESSION['userId'] ?? 0;
+    logModAction($mid, 'ban', 'user', $user_id);
+}
+
+function unbanUser(int $user_id): void {
+    global $conn;
+    $stmt = $conn->prepare('UPDATE users SET banned_until = NULL WHERE id = :id');
+    $stmt->execute([
+        ':id' => $user_id
+    ]);
+
+    $mid = $_SESSION['userId'] ?? 0;
+    logModAction($mid, 'unban', 'user', $user_id);
+}
+
+?>

--- a/core/users/user.php
+++ b/core/users/user.php
@@ -1,0 +1,23 @@
+<?php
+
+function getUserById(int $user_id) {
+    global $conn;
+    $stmt = $conn->prepare('SELECT id, username, rank, banned_until FROM users WHERE id = :id');
+    $stmt->execute([':id' => $user_id]);
+    return $stmt->fetch(PDO::FETCH_ASSOC);
+}
+
+function isUserBanned(int $user_id): bool {
+    $info = getUserById($user_id);
+    if (!$info || empty($info['banned_until'])) {
+        return false;
+    }
+    return strtotime($info['banned_until']) > time();
+}
+
+function fetchBannedUntil(int $user_id) {
+    $info = getUserById($user_id);
+    return $info ? $info['banned_until'] : null;
+}
+
+?>

--- a/public/forum/mod/ban_user.php
+++ b/public/forum/mod/ban_user.php
@@ -1,0 +1,37 @@
+<?php
+require("../../../core/conn.php");
+require_once("../../../core/settings.php");
+require_once("../../../core/forum/mod_check.php");
+require_once("../../../core/users/ban.php");
+
+forum_mod_check();
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $uid = (int)$_POST['user_id'];
+    $until = trim($_POST['ban_until'] ?? '');
+    if ($until !== '') {
+        banUser($uid, $until);
+        $message = "User $uid banned until $until";
+    } else {
+        unbanUser($uid);
+        $message = "User $uid unbanned";
+    }
+}
+
+$pageCSS = "../../static/css/forum.css";
+?>
+<?php require("../../header.php"); ?>
+<div class="simple-container">
+    <h1>Ban User</h1>
+    <form method="post">
+        <label>User ID: <input type="number" name="user_id" required></label><br>
+        <label>Ban Until (YYYY-MM-DD HH:MM:SS): <input type="text" name="ban_until"></label><br>
+        <button type="submit">Submit</button>
+    </form>
+    <?php if ($message): ?>
+    <p><?= htmlspecialchars($message) ?></p>
+    <?php endif; ?>
+</div>
+<?php require("../../footer.php"); ?>
+

--- a/public/index.php
+++ b/public/index.php
@@ -22,16 +22,18 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['action'])) {
         $password = $_POST['password'];
 
 
-        $stmt = $conn->prepare("SELECT id, username, password, rank FROM users WHERE email = ?");
+        $stmt = $conn->prepare("SELECT id, username, password, rank, banned_until FROM users WHERE email = ?");
         $stmt->execute(array($email));
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
 
-        if ($user && password_verify($password, $user['password'])) {
+        if ($user && password_verify($password, $user['password']) && (empty($user['banned_until']) || strtotime($user['banned_until']) <= time())) {
             $_SESSION['user'] = $user['username'];
             $_SESSION['userId'] = $user['id'];
             $_SESSION['rank'] = $user['rank'];
             header("Location: home.php");
             exit;
+        } elseif ($user && !empty($user['banned_until']) && strtotime($user['banned_until']) > time()) {
+            echo '<p>Account banned until ' . htmlspecialchars($user['banned_until']) . '</p><hr>';
         } else {
             echo '<p>Login information doesn\'t exist or incorrect password.</p><hr>';
         }

--- a/public/install.php
+++ b/public/install.php
@@ -178,6 +178,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                     `date` datetime NOT NULL,
                     `lastactive` datetime NULL DEFAULT NULL,
                     `lastlogon` datetime NULL DEFAULT NULL,
+                    `banned_until` datetime DEFAULT NULL,
                     `bio` varchar(500) NOT NULL DEFAULT '',
                     `interests` varchar(500) NOT NULL DEFAULT ' ',
                     `css` blob NOT NULL,

--- a/schema.sql
+++ b/schema.sql
@@ -237,6 +237,7 @@ CREATE TABLE IF NOT EXISTS `users` (
   `views` int(11) NOT NULL default '0',
   `lastactive` datetime NOT NULL,
   `lastlogon` datetime NOT NULL,
+  `banned_until` datetime DEFAULT NULL,
   PRIMARY KEY  (`id`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
 

--- a/tests/forum_bans.php
+++ b/tests/forum_bans.php
@@ -1,0 +1,115 @@
+<?php
+require_once __DIR__ . '/../core/users/ban.php';
+require_once __DIR__ . '/../core/helper.php';
+
+session_start();
+
+$dbFile = __DIR__ . '/forum_bans.db';
+@unlink($dbFile);
+$dsn = 'sqlite:' . $dbFile;
+putenv('DB_DSN=' . $dsn);
+
+$conn = new PDO($dsn);
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$conn->sqliteCreateFunction('NOW', function() { return date('Y-m-d H:i:s'); });
+$conn->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT, email TEXT, password TEXT, rank INTEGER, banned_until TEXT)');
+$conn->exec('CREATE TABLE mod_log (id INTEGER PRIMARY KEY AUTOINCREMENT, moderator_id INTEGER, action TEXT, target_type TEXT, target_id INTEGER, timestamp TEXT DEFAULT CURRENT_TIMESTAMP)');
+
+global $conn;
+
+// seed user
+$hash = password_hash('secret', PASSWORD_DEFAULT);
+$conn->prepare('INSERT INTO users (username, email, password, rank, banned_until) VALUES (?,?,?,?,NULL)')
+     ->execute(['alice', 'a@example.com', $hash, 0]);
+
+// moderator session
+$_SESSION = ['userId' => 99, 'user' => 'mod', 'rank' => 1];
+
+echo "Ban user...\n";
+$until = date('Y-m-d H:i:s', time() + 3600);
+banUser(1, $until);
+$banned = $conn->query('SELECT banned_until FROM users WHERE id = 1')->fetchColumn();
+$log = $conn->query("SELECT COUNT(*) FROM mod_log WHERE action = 'ban' AND target_id = 1")->fetchColumn();
+if ($banned === $until && (int)$log === 1) {
+    echo "User banned\n";
+} else {
+    echo "Ban failed\n";
+    unlink($dbFile);
+    exit(1);
+}
+
+echo "Login blocked...\n";
+$stmt = $conn->prepare('SELECT id, username, password, rank, banned_until FROM users WHERE email = ?');
+$stmt->execute(['a@example.com']);
+$user = $stmt->fetch(PDO::FETCH_ASSOC);
+if ($user && password_verify('secret', $user['password']) && (empty($user['banned_until']) || strtotime($user['banned_until']) <= time())) {
+    echo "Login allowed when should be banned\n";
+    unlink($dbFile);
+    exit(1);
+} else {
+    echo "Login denied\n";
+}
+
+echo "Session enforcement...\n";
+$script = <<<'PHP'
+<?php
+session_start();
+$dsn = getenv('DB_DSN');
+$conn = new PDO($dsn);
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+global $conn;
+require __DIR__ . '/../core/helper.php';
+$_SESSION = ['user' => 'alice', 'userId' => 1];
+login_check();
+echo "ALLOWED";
+PHP;
+file_put_contents(__DIR__ . '/check_ban.php', $script);
+$output = shell_exec('php ' . escapeshellarg(__DIR__ . '/check_ban.php'));
+$output = $output === null ? '' : trim($output);
+unlink(__DIR__ . '/check_ban.php');
+if ($output === '') {
+    echo "Access denied\n";
+} else {
+    echo "Session check failed\n";
+    unlink($dbFile);
+    exit(1);
+}
+
+echo "Unban user...\n";
+unbanUser(1);
+$banned = $conn->query('SELECT banned_until FROM users WHERE id = 1')->fetchColumn();
+$log = $conn->query("SELECT COUNT(*) FROM mod_log WHERE action = 'unban' AND target_id = 1")->fetchColumn();
+if (($banned === null || $banned === false) && (int)$log === 1) {
+    echo "User unbanned\n";
+} else {
+    echo "Unban failed\n";
+    unlink($dbFile);
+    exit(1);
+}
+
+echo "Login allowed after unban...\n";
+$stmt->execute(['a@example.com']);
+$user = $stmt->fetch(PDO::FETCH_ASSOC);
+if ($user && password_verify('secret', $user['password']) && (empty($user['banned_until']) || strtotime($user['banned_until']) <= time())) {
+    echo "Login allowed\n";
+} else {
+    echo "Login still blocked\n";
+    unlink($dbFile);
+    exit(1);
+}
+
+echo "Session allowed after unban...\n";
+file_put_contents(__DIR__ . '/check_ban.php', $script);
+$output = shell_exec('php ' . escapeshellarg(__DIR__ . '/check_ban.php'));
+$output = $output === null ? '' : trim($output);
+unlink(__DIR__ . '/check_ban.php');
+if ($output === 'ALLOWED') {
+    echo "Session ok\n";
+} else {
+    echo "Session still denied\n";
+    unlink($dbFile);
+    exit(1);
+}
+
+unlink($dbFile);
+?>


### PR DESCRIPTION
## Summary
- allow user bans via new `banned_until` column and helper functions
- add moderator ban/unban page
- enforce bans in login and session checks and cover with tests

## Testing
- `php tests/forum_bans.php`
- `for f in tests/*.php; do php $f; done`


------
https://chatgpt.com/codex/tasks/task_e_68953ab91f288321b8b3051b741600cb