### PR TITLE
Add forum word filter with moderator management

### DIFF
--- a/core/forum/word_filter.php
+++ b/core/forum/word_filter.php
@@ -1,0 +1,36 @@
+<?php
+require_once(__DIR__ . '/../helper.php');
+
+function bad_words_all(): array {
+    global $conn;
+    try {
+        $stmt = $conn->query('SELECT word FROM bad_words');
+        return $stmt->fetchAll(PDO::FETCH_COLUMN);
+    } catch (PDOException $e) {
+        return [];
+    }
+}
+
+function add_bad_word(string $word): void {
+    global $conn;
+    $stmt = $conn->prepare('INSERT INTO bad_words (word) VALUES (:w)');
+    $stmt->execute([':w' => $word]);
+}
+
+function remove_bad_word(string $word): void {
+    global $conn;
+    $stmt = $conn->prepare('DELETE FROM bad_words WHERE word = :w');
+    $stmt->execute([':w' => $word]);
+}
+
+function isFiltered(string $text): array {
+    $matches = [];
+    $words = bad_words_all();
+    foreach ($words as $w) {
+        if ($w !== '' && stripos($text, $w) !== false) {
+            $matches[] = $w;
+        }
+    }
+    return $matches;
+}
+?>

--- a/public/forum/mod/word_filter.php
+++ b/public/forum/mod/word_filter.php
@@ -1,0 +1,48 @@
+<?php
+require("../../../core/conn.php");
+require_once("../../../core/settings.php");
+require_once("../../../core/forum/mod_check.php");
+require_once("../../../core/forum/word_filter.php");
+
+forum_mod_check();
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+    $word = trim($_POST['word'] ?? '');
+    if ($action === 'add' && $word !== '') {
+        add_bad_word($word);
+        $message = 'Word added';
+    } elseif ($action === 'delete' && $word !== '') {
+        remove_bad_word($word);
+        $message = 'Word removed';
+    }
+}
+
+$words = bad_words_all();
+$pageCSS = "../../static/css/forum.css";
+?>
+<?php require("../../header.php"); ?>
+<div class="simple-container">
+    <h1>Word Filter</h1>
+    <form method="post">
+        <input type="hidden" name="action" value="add">
+        <input type="text" name="word" required>
+        <button type="submit">Add</button>
+    </form>
+    <?php if ($message): ?>
+    <p><?= htmlspecialchars($message) ?></p>
+    <?php endif; ?>
+    <ul>
+    <?php foreach ($words as $w): ?>
+        <li><?= htmlspecialchars($w) ?>
+            <form method="post" style="display:inline">
+                <input type="hidden" name="action" value="delete">
+                <input type="hidden" name="word" value="<?= htmlspecialchars($w) ?>">
+                <button type="submit">Remove</button>
+            </form>
+        </li>
+    <?php endforeach; ?>
+    </ul>
+</div>
+<?php require("../../footer.php"); ?>

--- a/public/forum/post.php
+++ b/public/forum/post.php
@@ -68,6 +68,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $result = forum_add_post($topicId, $_SESSION['userId'], $body);
         if (isset($result['error'])) {
             $error = $result['error'];
+        } elseif (isset($result['warning'])) {
+            $error = $result['warning'] . ': ' . implode(', ', $result['filtered']);
         } else {
             header('Location: post.php?id=' . $topicId);
             exit;

--- a/public/forum/topic.php
+++ b/public/forum/topic.php
@@ -40,9 +40,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $title = $_POST['title'] ?? '';
     $body = $_POST['body'] ?? '';
     if ($title !== '' && $body !== '') {
-        $topicId = forum_create_topic($forumId, $_SESSION['userId'], $title, $body);
-        header('Location: post.php?id=' . $topicId);
-        exit;
+        $result = forum_create_topic($forumId, $_SESSION['userId'], $title, $body);
+        if (is_array($result)) {
+            if (isset($result['warning'])) {
+                $error = $result['warning'] . ': ' . implode(', ', $result['filtered']);
+            } else {
+                $error = $result['error'] ?? 'Unable to create topic.';
+            }
+        } else {
+            header('Location: post.php?id=' . $result);
+            exit;
+        }
     } else {
         $error = 'Title and body are required.';
     }

--- a/schema.sql
+++ b/schema.sql
@@ -382,3 +382,15 @@ CREATE TABLE IF NOT EXISTS `mod_log` (
   PRIMARY KEY (`id`),
   FOREIGN KEY (`moderator_id`) REFERENCES `users` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- --------------------------------------------------------
+--
+-- Table structure for table `bad_words`
+--
+CREATE TABLE IF NOT EXISTS `bad_words` (
+  `id` int(11) NOT NULL auto_increment,
+  `word` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `bad_words` (`word`) VALUES ('badword'), ('evil');

--- a/tests/forum_word_filter.php
+++ b/tests/forum_word_filter.php
@@ -1,0 +1,47 @@
+<?php
+require_once __DIR__ . '/../core/forum/topic.php';
+require_once __DIR__ . '/../core/forum/post.php';
+require_once __DIR__ . '/../core/forum/permissions.php';
+require_once __DIR__ . '/../core/forum/word_filter.php';
+
+session_start();
+
+$dbFile = __DIR__ . '/forum_word_filter.db';
+@unlink($dbFile);
+$dsn = 'sqlite:' . $dbFile;
+putenv('DB_DSN=' . $dsn);
+
+$conn = new PDO($dsn);
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$conn->sqliteCreateFunction('NOW', function() { return date('Y-m-d H:i:s'); });
+$conn->exec('CREATE TABLE forum_topics (id INTEGER PRIMARY KEY AUTOINCREMENT, forum_id INTEGER, title TEXT, locked INTEGER DEFAULT 0, sticky INTEGER DEFAULT 0, moved_to INTEGER DEFAULT NULL)');
+$conn->exec('CREATE TABLE forum_posts (id INTEGER PRIMARY KEY AUTOINCREMENT, topic_id INTEGER, user_id INTEGER, body TEXT, created_at TEXT DEFAULT CURRENT_TIMESTAMP, deleted INTEGER DEFAULT 0, deleted_by INTEGER, deleted_at TEXT)');
+$conn->exec('CREATE TABLE mod_log (id INTEGER PRIMARY KEY AUTOINCREMENT, moderator_id INTEGER, action TEXT, target_type TEXT, target_id INTEGER, timestamp TEXT DEFAULT CURRENT_TIMESTAMP)');
+$conn->exec('CREATE TABLE forum_permissions (forum_id INTEGER, role TEXT, can_view INTEGER, can_post INTEGER, can_moderate INTEGER)');
+$conn->exec('CREATE TABLE forum_moderators (forum_id INTEGER, user_id INTEGER)');
+$conn->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT)');
+$conn->exec('CREATE TABLE bad_words (id INTEGER PRIMARY KEY AUTOINCREMENT, word TEXT)');
+$conn->exec("INSERT INTO bad_words (word) VALUES ('badword')");
+$conn->exec("INSERT INTO forum_permissions (forum_id, role, can_view, can_post, can_moderate) VALUES (1, 'member', 1, 1, 0)");
+$conn->exec("INSERT INTO forum_permissions (forum_id, role, can_view, can_post, can_moderate) VALUES (1, 'guest', 1, 0, 0)");
+$conn->exec("INSERT INTO forum_moderators (forum_id, user_id) VALUES (1, 2)");
+$conn->exec("INSERT INTO users (id, username) VALUES (1, 'alice'), (2, 'bob')");
+
+global $conn;
+
+$_SESSION = ['userId' => 1, 'user' => 'alice', 'rank' => 0];
+$tid = forum_create_topic(1, 1, 'Topic', 'Clean first post');
+
+echo "Filtering post...\n";
+$result = forum_add_post($tid, 1, 'This post has badword in it');
+$deleted = $conn->query('SELECT deleted FROM forum_posts WHERE id = 2')->fetchColumn();
+if (isset($result['filtered']) && (int)$deleted === 1) {
+    echo "Filtered\n";
+    unlink($dbFile);
+    exit(0);
+}
+
+echo "Filter failed\n";
+unlink($dbFile);
+exit(1);
+?>


### PR DESCRIPTION
## Summary
- Add `bad_words` table and seed entries
- Implement helper to detect filtered words and integrate into post and topic creation
- Provide moderator UI to manage filtered words
- Warn users when posts or topics contain filtered words
- Add tests covering word filter

## Testing
- `for f in tests/*.php; do echo "Running $f"; php $f; echo; done`

------
https://chatgpt.com/codex/tasks/task_e_68953ddc5be4832184ab28f6134ef526