### PR TITLE
Add moderator dashboard with moderation metrics and tests

### DIFF
--- a/core/components/navbar.php
+++ b/core/components/navbar.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . "/../forum/permissions.php"; ?>
 <!-- BEGIN HEADER -->
 <header class="main-header">
   <nav class="">
@@ -66,6 +67,10 @@
           $activeClass = ($currentPage == basename($page)) ? 'class="active"' : '';
         }
         echo "<li><a href=\"$page\" $activeClass>&nbsp;$name </a></li>";
+      }
+      if (in_array(forum_user_role(), ['admin','global_mod'])) {
+        $activeClass = ($currentPage == 'dashboard.php') ? 'class="active"' : '';
+        echo "<li><a href=\"/forum/mod/dashboard.php\" $activeClass>Mod</a></li>";
       }
       ?>
     </ul>

--- a/core/forum/mod_dashboard.php
+++ b/core/forum/mod_dashboard.php
@@ -1,0 +1,29 @@
+<?php
+
+function countOpenReports(): int {
+    global $conn;
+    $stmt = $conn->query('SELECT COUNT(*) FROM reports WHERE status = "open"');
+    return (int)$stmt->fetchColumn();
+}
+
+function countUnresolvedPosts(): int {
+    global $conn;
+    $stmt = $conn->query('SELECT COUNT(*) FROM forum_posts WHERE deleted = 1');
+    return (int)$stmt->fetchColumn();
+}
+
+function countActiveBans(): int {
+    global $conn;
+    $stmt = $conn->query('SELECT COUNT(*) FROM users WHERE banned_until IS NOT NULL AND banned_until > CURRENT_TIMESTAMP');
+    return (int)$stmt->fetchColumn();
+}
+
+function getLatestLogEntries(int $limit = 5): array {
+    global $conn;
+    $stmt = $conn->prepare('SELECT l.*, u.username FROM mod_log l JOIN users u ON l.moderator_id = u.id ORDER BY l.timestamp DESC LIMIT :lim');
+    $stmt->bindValue(':lim', $limit, PDO::PARAM_INT);
+    $stmt->execute();
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+?>

--- a/public/forum/mod/dashboard.php
+++ b/public/forum/mod/dashboard.php
@@ -1,0 +1,41 @@
+<?php
+require __DIR__ . "/../../../core/conn.php";
+require_once __DIR__ . "/../../../core/settings.php";
+require_once __DIR__ . "/../../../core/forum/mod_check.php";
+require_once __DIR__ . "/../../../core/forum/mod_dashboard.php";
+
+forum_mod_check();
+
+$openReports = countOpenReports();
+$unresolvedPosts = countUnresolvedPosts();
+$activeBans = countActiveBans();
+$latestLogs = getLatestLogEntries();
+
+$pageCSS = "../../static/css/mod.css";
+?>
+<?php require __DIR__ . "/../../header.php"; ?>
+<div class="mod-dashboard">
+    <h1>Moderator Dashboard</h1>
+    <div class="stats">
+        <div class="stat">Open Reports: <?= $openReports ?></div>
+        <div class="stat">Unresolved Posts: <?= $unresolvedPosts ?></div>
+        <div class="stat">Active Bans: <?= $activeBans ?></div>
+    </div>
+    <h2>Latest Log Entries</h2>
+    <?php if (empty($latestLogs)): ?>
+    <p>No log entries.</p>
+    <?php else: ?>
+    <table class="forum-table">
+        <tr><th>Time</th><th>Moderator</th><th>Action</th><th>Target</th></tr>
+        <?php foreach ($latestLogs as $log): ?>
+        <tr>
+            <td><?= htmlspecialchars($log['timestamp']) ?></td>
+            <td><?= htmlspecialchars($log['username']) ?></td>
+            <td><?= htmlspecialchars($log['action']) ?></td>
+            <td><?= htmlspecialchars($log['target_type'] . ' #' . $log['target_id']) ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </table>
+    <?php endif; ?>
+</div>
+<?php require __DIR__ . "/../../footer.php"; ?>

--- a/public/static/css/mod.css
+++ b/public/static/css/mod.css
@@ -1,0 +1,26 @@
+@import url("forum.css");
+
+/* Moderator dashboard styles */
+.mod-dashboard {
+    margin: 1em;
+}
+.mod-dashboard .stats {
+    display: flex;
+    gap: 1em;
+    margin-bottom: 1em;
+}
+.mod-dashboard .stat {
+    background: #f0f0f0;
+    padding: 0.5em 1em;
+    border-radius: 4px;
+}
+.mod-dashboard table {
+    width: 100%;
+    border-collapse: collapse;
+}
+.mod-dashboard th,
+.mod-dashboard td {
+    border: 1px solid #ccc;
+    padding: 0.5em;
+    text-align: left;
+}

--- a/tests/forum_mod_dashboard.php
+++ b/tests/forum_mod_dashboard.php
@@ -1,0 +1,52 @@
+<?php
+require_once __DIR__ . '/../core/forum/mod_dashboard.php';
+
+session_start();
+
+$dbFile = __DIR__ . '/forum_mod_dashboard.db';
+@unlink($dbFile);
+$dsn = 'sqlite:' . $dbFile;
+putenv('DB_DSN=' . $dsn);
+
+$conn = new PDO($dsn);
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$conn->exec('CREATE TABLE reports (id INTEGER PRIMARY KEY AUTOINCREMENT, reported_id INTEGER, type TEXT, reason TEXT, reporter_id INTEGER, status TEXT)');
+$conn->exec('CREATE TABLE forum_posts (id INTEGER PRIMARY KEY AUTOINCREMENT, topic_id INTEGER, user_id INTEGER, body TEXT, created_at TEXT, deleted INTEGER DEFAULT 0, deleted_by INTEGER DEFAULT NULL, deleted_at TEXT DEFAULT NULL)');
+$conn->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, rank INTEGER, username TEXT, email TEXT, password TEXT, banned_until TEXT)');
+$conn->exec('CREATE TABLE mod_log (id INTEGER PRIMARY KEY AUTOINCREMENT, moderator_id INTEGER, action TEXT, target_type TEXT, target_id INTEGER, timestamp TEXT DEFAULT CURRENT_TIMESTAMP)');
+
+global $conn;
+
+// seed data
+$conn->exec("INSERT INTO reports (reported_id, type, reason, reporter_id, status) VALUES (1, 'post', 'spam', 2, 'open'), (2, 'post', 'spam', 3, 'closed')");
+$conn->exec("INSERT INTO forum_posts (topic_id, user_id, body, created_at, deleted) VALUES (1,1,'a',datetime('now'),0), (1,1,'b',datetime('now'),1)");
+$hash = password_hash('secret', PASSWORD_DEFAULT);
+$conn->exec("INSERT INTO users (username,email,password,rank,banned_until) VALUES ('mod','m@example.com','$hash',1,NULL), ('banned','b@example.com','$hash',0, datetime('now', '+1 hour'))");
+$conn->exec("INSERT INTO mod_log (moderator_id, action, target_type, target_id, timestamp) VALUES (1,'ban','user',2,datetime('now')), (1,'delete','post',1,datetime('now'))");
+
+$_SESSION = ['userId' => 1, 'user' => 'mod', 'rank' => 1];
+
+$siteName = 'AnySpace';
+$domainName = 'example.com';
+$adminUser = 1;
+
+ob_start();
+require __DIR__ . '/../public/forum/mod/dashboard.php';
+$output = ob_get_clean();
+
+$ok = true;
+$ok = $ok && strpos($output, 'Open Reports: 1') !== false;
+$ok = $ok && strpos($output, 'Unresolved Posts: 1') !== false;
+$ok = $ok && strpos($output, 'Active Bans: 1') !== false;
+$ok = $ok && strpos($output, 'ban') !== false && strpos($output, 'delete') !== false;
+
+if ($ok) {
+    echo "Dashboard shows correct counts\n";
+} else {
+    echo "Dashboard incorrect\n";
+    unlink($dbFile);
+    exit(1);
+}
+
+unlink($dbFile);
+?>


### PR DESCRIPTION
## Summary
- Add moderator dashboard with counts for reports, deleted posts, active bans, and recent log entries.
- Introduce helper functions to fetch moderation metrics and link dashboard for mods/admins via navbar.
- Style dashboard with dedicated CSS and cover behavior with regression test.

## Testing
- `php tests/forum_bans.php`
- `php tests/forum_delete.php`
- `php tests/forum_mod_log.php`
- `php tests/forum_notifications.php`
- `php tests/forum_permissions.php`
- `php tests/forum_posts.php`
- `php tests/forum_reports.php`
- `php tests/forum_search.php`
- `php tests/forum_topics.php`
- `php tests/forum_public.php`
- `php tests/forum_word_filter.php`
- `php tests/forum_mod_dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68953fa610fc8321bd825811a4640749