### PR TITLE
Add basic private messaging system

### DIFF
--- a/core/components/navbar.php
+++ b/core/components/navbar.php
@@ -1,4 +1,12 @@
-<?php require_once __DIR__ . "/../forum/permissions.php"; ?>
+<?php
+require_once __DIR__ . "/../forum/permissions.php";
+if (isset($_SESSION['userId'])) {
+    require_once __DIR__ . "/../messages/pm.php";
+    $unreadMessages = pm_unread_count($_SESSION['userId']);
+} else {
+    $unreadMessages = 0;
+}
+?>
 <!-- BEGIN HEADER -->
 <header class="main-header">
   <nav class="">
@@ -48,7 +56,7 @@
         'Home' => '/index.php',
         'Browse' => '/browse.php',
         'Search' => '/search.php',
-        'Mail' => '/messages.php',
+        'Mail' => '/messages/inbox.php',
         'Blog' => '/blog/',
         'Bulletins' => '/bulletins/',
         'Forum' => '/forum/forums.php',
@@ -66,7 +74,11 @@
         } else {
           $activeClass = ($currentPage == basename($page)) ? 'class="active"' : '';
         }
-        echo "<li><a href=\"$page\" $activeClass>&nbsp;$name </a></li>";
+        $display = $name;
+        if ($name === 'Mail' && $unreadMessages > 0) {
+          $display .= ' (' . $unreadMessages . ')';
+        }
+        echo "<li><a href=\"$page\" $activeClass>&nbsp;$display </a></li>";
       }
       if (in_array(forum_user_role(), ['admin','global_mod'])) {
         $activeClass = ($currentPage == 'dashboard.php') ? 'class="active"' : '';

--- a/core/messages/pm.php
+++ b/core/messages/pm.php
@@ -1,0 +1,46 @@
+<?php
+require_once __DIR__ . '/../helper.php';
+
+function pm_send(int $sender_id, int $receiver_id, string $subject, string $body): int
+{
+    global $conn;
+    $cleanSubject = trim(strip_tags($subject));
+    $cleanBody = validateContentHTML($body);
+    $stmt = $conn->prepare('INSERT INTO messages (sender_id, receiver_id, subject, body, sent_at) VALUES (:sid, :rid, :sub, :body, CURRENT_TIMESTAMP)');
+    $stmt->execute([':sid' => $sender_id, ':rid' => $receiver_id, ':sub' => $cleanSubject, ':body' => $cleanBody]);
+    return (int)$conn->lastInsertId();
+}
+
+function pm_inbox(int $user_id): array
+{
+    global $conn;
+    $stmt = $conn->prepare('SELECT m.id, m.sender_id, m.receiver_id, m.subject, m.body, m.sent_at, m.read_at, u.username AS sender FROM messages m JOIN users u ON m.sender_id = u.id WHERE m.receiver_id = :uid ORDER BY m.sent_at DESC');
+    $stmt->execute([':uid' => $user_id]);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function pm_outbox(int $user_id): array
+{
+    global $conn;
+    $stmt = $conn->prepare('SELECT m.id, m.sender_id, m.receiver_id, m.subject, m.body, m.sent_at, m.read_at, u.username AS receiver FROM messages m JOIN users u ON m.receiver_id = u.id WHERE m.sender_id = :uid ORDER BY m.sent_at DESC');
+    $stmt->execute([':uid' => $user_id]);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function pm_mark_read(int $message_id, int $user_id): void
+{
+    global $conn;
+    $stmt = $conn->prepare('UPDATE messages SET read_at = CURRENT_TIMESTAMP WHERE id = :id AND receiver_id = :uid AND read_at IS NULL');
+    $stmt->execute([':id' => $message_id, ':uid' => $user_id]);
+}
+
+function pm_unread_count(int $user_id): int
+{
+    global $conn;
+    $stmt = $conn->prepare('SELECT COUNT(*) FROM messages WHERE receiver_id = :uid AND read_at IS NULL');
+    $stmt->execute([':uid' => $user_id]);
+    return (int)$stmt->fetchColumn();
+}
+
+?>
+

--- a/public/messages/compose.php
+++ b/public/messages/compose.php
@@ -1,0 +1,45 @@
+<?php
+require("../../core/conn.php");
+require_once("../../core/settings.php");
+require("../../core/messages/pm.php");
+
+login_check();
+
+$userId = $_SESSION['userId'];
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $to = trim($_POST['to'] ?? '');
+    $subject = trim($_POST['subject'] ?? '');
+    $body = trim($_POST['body'] ?? '');
+
+    $stmt = $conn->prepare('SELECT id FROM users WHERE username = :name');
+    $stmt->execute([':name' => $to]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($row) {
+        pm_send($userId, (int)$row['id'], $subject, $body);
+        $message = 'Message sent!';
+    } else {
+        $message = 'User not found.';
+    }
+}
+?>
+<?php require("../header.php"); ?>
+
+<div class="simple-container">
+    <h1>Compose Message</h1>
+    <p><a href="inbox.php">Inbox</a> | <a href="outbox.php">Outbox</a></p>
+    <?php if ($message): ?>
+        <p><?= htmlspecialchars($message) ?></p>
+    <?php endif; ?>
+    <form method="post">
+        <p><label>To: <input type="text" name="to" required></label></p>
+        <p><label>Subject: <input type="text" name="subject" required></label></p>
+        <p><label>Message:<br>
+            <textarea name="body" rows="8" cols="40" required></textarea></label></p>
+        <p><button type="submit">Send</button></p>
+    </form>
+</div>
+
+<?php require("../footer.php"); ?>
+

--- a/public/messages/inbox.php
+++ b/public/messages/inbox.php
@@ -1,0 +1,43 @@
+<?php
+require("../../core/conn.php");
+require_once("../../core/settings.php");
+require("../../core/messages/pm.php");
+
+login_check();
+
+$userId = $_SESSION['userId'];
+
+if (isset($_GET['mark'])) {
+    pm_mark_read((int)$_GET['mark'], $userId);
+    header('Location: inbox.php');
+    exit;
+}
+
+$messages = pm_inbox($userId);
+?>
+<?php require("../header.php"); ?>
+
+<div class="simple-container">
+    <h1>Inbox</h1>
+    <p><a href="compose.php">Compose</a> | <a href="outbox.php">Outbox</a></p>
+    <?php if (empty($messages)): ?>
+        <p>No messages.</p>
+    <?php else: ?>
+        <ul>
+            <?php foreach ($messages as $msg): ?>
+                <li>
+                    <strong><a href="?mark=<?= $msg['id'] ?>"><?= htmlspecialchars($msg['subject']) ?></a></strong>
+                    from <a href="../profile.php?id=<?= $msg['sender_id'] ?>"><?= htmlspecialchars($msg['sender']) ?></a>
+                    on <?= htmlspecialchars($msg['sent_at']) ?>
+                    <?php if (empty($msg['read_at'])): ?>
+                        <em>(unread)</em>
+                    <?php endif; ?>
+                    <div><?= nl2br(htmlspecialchars($msg['body'])) ?></div>
+                </li>
+            <?php endforeach; ?>
+        </ul>
+    <?php endif; ?>
+</div>
+
+<?php require("../footer.php"); ?>
+

--- a/public/messages/outbox.php
+++ b/public/messages/outbox.php
@@ -1,0 +1,36 @@
+<?php
+require("../../core/conn.php");
+require_once("../../core/settings.php");
+require("../../core/messages/pm.php");
+
+login_check();
+
+$userId = $_SESSION['userId'];
+$messages = pm_outbox($userId);
+?>
+<?php require("../header.php"); ?>
+
+<div class="simple-container">
+    <h1>Outbox</h1>
+    <p><a href="compose.php">Compose</a> | <a href="inbox.php">Inbox</a></p>
+    <?php if (empty($messages)): ?>
+        <p>No messages.</p>
+    <?php else: ?>
+        <ul>
+            <?php foreach ($messages as $msg): ?>
+                <li>
+                    <strong><?= htmlspecialchars($msg['subject']) ?></strong>
+                    to <a href="../profile.php?id=<?= $msg['receiver_id'] ?>"><?= htmlspecialchars($msg['receiver']) ?></a>
+                    on <?= htmlspecialchars($msg['sent_at']) ?>
+                    <?php if (empty($msg['read_at'])): ?>
+                        <em>(unread)</em>
+                    <?php endif; ?>
+                    <div><?= nl2br(htmlspecialchars($msg['body'])) ?></div>
+                </li>
+            <?php endforeach; ?>
+        </ul>
+    <?php endif; ?>
+</div>
+
+<?php require("../footer.php"); ?>
+

--- a/schema.sql
+++ b/schema.sql
@@ -169,16 +169,17 @@ CREATE TABLE IF NOT EXISTS `layouts` (
 -- --------------------------------------------------------
 
 --
--- Table structure for table `messages`
---
 
 CREATE TABLE IF NOT EXISTS `messages` (
   `id` int(11) NOT NULL auto_increment,
-  `toid` int(11) NOT NULL,
-  `author` int(11) NOT NULL,
-  `msg` text NOT NULL,
+  `sender_id` int(11) NOT NULL,
+  `receiver_id` int(11) NOT NULL,
+  `subject` varchar(255) NOT NULL,
+  `body` text NOT NULL,
+  `sent_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `read_at` datetime DEFAULT NULL,
   PRIMARY KEY  (`id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- --------------------------------------------------------
 

--- a/tests/messages_pm.php
+++ b/tests/messages_pm.php
@@ -1,0 +1,43 @@
+<?php
+// Regression test for private messages: sending and reading.
+
+session_start();
+require_once __DIR__ . '/../core/messages/pm.php';
+
+$dbFile = __DIR__ . '/messages_pm.db';
+@unlink($dbFile);
+$dsn = 'sqlite:' . $dbFile;
+putenv('DB_DSN=' . $dsn);
+
+$conn = new PDO($dsn);
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+global $conn;
+
+$conn->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT)');
+$conn->exec('CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, sender_id INTEGER, receiver_id INTEGER, subject TEXT, body TEXT, sent_at TEXT DEFAULT CURRENT_TIMESTAMP, read_at TEXT DEFAULT NULL)');
+$conn->exec("INSERT INTO users (id, username) VALUES (1, 'alice'), (2, 'bob')");
+
+echo "Send message...\n";
+pm_send(1, 2, 'Hi', 'Hello Bob');
+$inbox = pm_inbox(2);
+if (count($inbox) !== 1 || $inbox[0]['subject'] !== 'Hi') {
+    echo "Send failed\n";
+    unlink($dbFile);
+    exit(1);
+}
+echo "Message received\n";
+
+echo "Mark read...\n";
+pm_mark_read($inbox[0]['id'], 2);
+$read = $conn->query('SELECT read_at FROM messages WHERE id = ' . (int)$inbox[0]['id'])->fetchColumn();
+if ($read) {
+    echo "Message read\n";
+} else {
+    echo "Read failed\n";
+    unlink($dbFile);
+    exit(1);
+}
+
+unlink($dbFile);
+?>
+


### PR DESCRIPTION
## Summary
- Add `messages` table with sender/receiver, subject/body, and timestamps
- Implement `pm_send`, inbox/outbox retrieval, unread count, and mark-as-read helpers
- Build inbox, outbox, and compose pages with session protection
- Show inbox link and unread message count in navbar
- Cover message send/read flow with regression test

## Testing
- `php tests/messages_pm.php`


------
https://chatgpt.com/codex/tasks/task_e_68954424ee80832184be38258ef81de1