### PR TITLE
Add forum topic subscription feature with notifications

### DIFF
--- a/core/forum/post.php
+++ b/core/forum/post.php
@@ -3,6 +3,7 @@
 require_once(__DIR__ . '/topic.php');
 require_once(__DIR__ . '/../helper.php');
 require_once(__DIR__ . '/notifications.php');
+require_once(__DIR__ . '/subscriptions.php');
 require_once(__DIR__ . '/mod_log.php');
 require_once(__DIR__ . '/word_filter.php');
 require_once(__DIR__ . '/../../lib/upload.php');
@@ -51,6 +52,17 @@ function forum_add_post(int $topic_id, int $user_id, string $body)
                     $notified[] = $uid;
                 }
             }
+        }
+    }
+
+    $subStmt = $conn->prepare('SELECT user_id FROM topic_subscriptions WHERE topic_id = :tid');
+    $subStmt->execute([':tid' => $topic_id]);
+    $subs = $subStmt->fetchAll(PDO::FETCH_COLUMN);
+    foreach ($subs as $uid) {
+        $uid = (int)$uid;
+        if ($uid !== $user_id && !in_array($uid, $notified, true)) {
+            notifications_add($uid, $postId);
+            $notified[] = $uid;
         }
     }
 

--- a/core/forum/subscriptions.php
+++ b/core/forum/subscriptions.php
@@ -1,0 +1,24 @@
+<?php
+
+function subscribeTopic(int $user_id, int $topic_id): bool {
+    global $conn;
+    $check = $conn->prepare('SELECT COUNT(*) FROM topic_subscriptions WHERE user_id = :uid AND topic_id = :tid');
+    $check->execute([':uid' => $user_id, ':tid' => $topic_id]);
+    if ((int)$check->fetchColumn() > 0) {
+        $del = $conn->prepare('DELETE FROM topic_subscriptions WHERE user_id = :uid AND topic_id = :tid');
+        $del->execute([':uid' => $user_id, ':tid' => $topic_id]);
+        return false; // unsubscribed
+    }
+    $ins = $conn->prepare('INSERT INTO topic_subscriptions (user_id, topic_id) VALUES (:uid, :tid)');
+    $ins->execute([':uid' => $user_id, ':tid' => $topic_id]);
+    return true; // subscribed
+}
+
+function getUserSubscriptions(int $user_id): array {
+    global $conn;
+    $stmt = $conn->prepare('SELECT t.id, t.title FROM topic_subscriptions s JOIN forum_topics t ON s.topic_id = t.id WHERE s.user_id = :uid');
+    $stmt->execute([':uid' => $user_id]);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+?>

--- a/public/forum/subscriptions.php
+++ b/public/forum/subscriptions.php
@@ -1,0 +1,26 @@
+<?php
+require("../../core/conn.php");
+require_once("../../core/settings.php");
+require_once("../../core/forum/subscriptions.php");
+require_once("../../core/helper.php");
+
+login_check();
+
+$subs = getUserSubscriptions($_SESSION['userId']);
+
+$pageCSS = "../static/css/forum.css";
+?>
+<?php require("../header.php"); ?>
+<div class="simple-container">
+    <h1>My Subscriptions</h1>
+    <?php if (empty($subs)): ?>
+        <p>No subscriptions.</p>
+    <?php else: ?>
+        <ul>
+        <?php foreach ($subs as $s): ?>
+            <li><a href="post.php?id=<?= $s['id'] ?>" aria-label="View subscribed topic <?= htmlspecialchars($s['title']) ?>" role="link"><?= htmlspecialchars($s['title']) ?></a></li>
+        <?php endforeach; ?>
+        </ul>
+    <?php endif; ?>
+</div>
+<?php require("../footer.php"); ?>

--- a/schema.sql
+++ b/schema.sql
@@ -315,6 +315,18 @@ CREATE TABLE IF NOT EXISTS `attachments` (
   FOREIGN KEY (`post_id`) REFERENCES `forum_posts` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+-- --------------------------------------------------------
+--
+-- Table structure for table `topic_subscriptions`
+--
+CREATE TABLE IF NOT EXISTS `topic_subscriptions` (
+  `user_id` int(11) NOT NULL,
+  `topic_id` int(11) NOT NULL,
+  PRIMARY KEY (`user_id`, `topic_id`),
+  FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  FOREIGN KEY (`topic_id`) REFERENCES `forum_topics` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
 
 -- --------------------------------------------------------
 --

--- a/tests/forum_mod_dashboard.php
+++ b/tests/forum_mod_dashboard.php
@@ -14,6 +14,7 @@ $conn->exec('CREATE TABLE reports (id INTEGER PRIMARY KEY AUTOINCREMENT, reporte
 $conn->exec('CREATE TABLE forum_posts (id INTEGER PRIMARY KEY AUTOINCREMENT, topic_id INTEGER, user_id INTEGER, body TEXT, created_at TEXT, deleted INTEGER DEFAULT 0, deleted_by INTEGER DEFAULT NULL, deleted_at TEXT DEFAULT NULL)');
 $conn->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, rank INTEGER, username TEXT, email TEXT, password TEXT, banned_until TEXT)');
 $conn->exec('CREATE TABLE mod_log (id INTEGER PRIMARY KEY AUTOINCREMENT, moderator_id INTEGER, action TEXT, target_type TEXT, target_id INTEGER, timestamp TEXT DEFAULT CURRENT_TIMESTAMP)');
+$conn->exec('CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, sender_id INTEGER, receiver_id INTEGER, subject TEXT, body TEXT, sent_at TEXT, read_at TEXT DEFAULT NULL)');
 
 global $conn;
 

--- a/tests/forum_notifications.php
+++ b/tests/forum_notifications.php
@@ -15,6 +15,7 @@ $conn->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username 
 $conn->exec('CREATE TABLE forum_topics (id INTEGER PRIMARY KEY AUTOINCREMENT, locked INTEGER DEFAULT 0)');
 $conn->exec('CREATE TABLE forum_posts (id INTEGER PRIMARY KEY AUTOINCREMENT, topic_id INTEGER, user_id INTEGER, body TEXT, created_at DATETIME)');
 $conn->exec('CREATE TABLE notifications (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, post_id INTEGER, is_read INTEGER DEFAULT 0, created_at DATETIME)');
+$conn->exec('CREATE TABLE topic_subscriptions (user_id INTEGER, topic_id INTEGER, PRIMARY KEY(user_id, topic_id))');
 
 $conn->exec("INSERT INTO users (username) VALUES ('owner'), ('replier'), ('mentioned')");
 $conn->exec("INSERT INTO forum_topics (id, locked) VALUES (1,0)");

--- a/tests/forum_posts.php
+++ b/tests/forum_posts.php
@@ -24,6 +24,7 @@ $conn->exec('CREATE TABLE mod_log (id INTEGER PRIMARY KEY AUTOINCREMENT, moderat
 $conn->exec('CREATE TABLE forum_permissions (forum_id INTEGER, role TEXT, can_view INTEGER, can_post INTEGER, can_moderate INTEGER)');
 $conn->exec('CREATE TABLE forum_moderators (forum_id INTEGER, user_id INTEGER)');
 $conn->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT)');
+$conn->exec('CREATE TABLE topic_subscriptions (user_id INTEGER, topic_id INTEGER, PRIMARY KEY(user_id, topic_id))');
 $conn->exec("INSERT INTO forum_permissions (forum_id, role, can_view, can_post, can_moderate) VALUES (1, 'member', 1, 1, 0)");
 $conn->exec("INSERT INTO forum_permissions (forum_id, role, can_view, can_post, can_moderate) VALUES (1, 'guest', 1, 0, 0)");
 $conn->exec("INSERT INTO forum_moderators (forum_id, user_id) VALUES (1, 2)");

--- a/tests/forum_subscriptions.php
+++ b/tests/forum_subscriptions.php
@@ -1,0 +1,48 @@
+<?php
+require_once __DIR__ . '/../core/forum/post.php';
+require_once __DIR__ . '/../core/forum/notifications.php';
+require_once __DIR__ . '/../core/forum/subscriptions.php';
+
+$dbFile = __DIR__ . '/forum_test.db';
+@unlink($dbFile);
+$dsn = 'sqlite:' . $dbFile;
+putenv('DB_DSN=' . $dsn);
+
+$conn = new PDO($dsn);
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+global $conn;
+
+$conn->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT)');
+$conn->exec('CREATE TABLE forum_topics (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, locked INTEGER DEFAULT 0)');
+$conn->exec('CREATE TABLE forum_posts (id INTEGER PRIMARY KEY AUTOINCREMENT, topic_id INTEGER, user_id INTEGER, body TEXT, created_at DATETIME, deleted INTEGER DEFAULT 0, deleted_by INTEGER, deleted_at DATETIME)');
+$conn->exec('CREATE TABLE notifications (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, post_id INTEGER, is_read INTEGER DEFAULT 0, created_at DATETIME)');
+$conn->exec('CREATE TABLE topic_subscriptions (user_id INTEGER, topic_id INTEGER, PRIMARY KEY(user_id, topic_id))');
+
+$conn->exec("INSERT INTO users (username) VALUES ('owner'), ('subscriber'), ('replier')");
+$conn->exec("INSERT INTO forum_topics (title, locked) VALUES ('Test', 0)");
+$conn->exec("INSERT INTO forum_posts (topic_id, user_id, body, created_at) VALUES (1,1,'first',datetime('now'))");
+
+subscribeTopic(2,1);
+$subs = getUserSubscriptions(2);
+subscribeTopic(2,1);
+$subs2 = getUserSubscriptions(2);
+
+if (count($subs) === 1 && count($subs2) === 0) {
+    echo "Subscription toggling works\n";
+} else {
+    echo "Subscription toggling failed\n";
+    exit(1);
+}
+
+subscribeTopic(2,1);
+forum_add_post(1,3,'reply');
+
+if (notifications_unread_count(2) === 1) {
+    echo "Subscription notification created\n";
+} else {
+    echo "Subscription notification failed\n";
+    exit(1);
+}
+
+unlink($dbFile);
+?>

--- a/tests/forum_word_filter.php
+++ b/tests/forum_word_filter.php
@@ -20,6 +20,7 @@ $conn->exec('CREATE TABLE mod_log (id INTEGER PRIMARY KEY AUTOINCREMENT, moderat
 $conn->exec('CREATE TABLE forum_permissions (forum_id INTEGER, role TEXT, can_view INTEGER, can_post INTEGER, can_moderate INTEGER)');
 $conn->exec('CREATE TABLE forum_moderators (forum_id INTEGER, user_id INTEGER)');
 $conn->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT)');
+$conn->exec('CREATE TABLE topic_subscriptions (user_id INTEGER, topic_id INTEGER, PRIMARY KEY(user_id, topic_id))');
 $conn->exec('CREATE TABLE bad_words (id INTEGER PRIMARY KEY AUTOINCREMENT, word TEXT)');
 $conn->exec("INSERT INTO bad_words (word) VALUES ('badword')");
 $conn->exec("INSERT INTO forum_permissions (forum_id, role, can_view, can_post, can_moderate) VALUES (1, 'member', 1, 1, 0)");


### PR DESCRIPTION
## Summary
- add `topic_subscriptions` table to schema
- allow users to subscribe to topics and view their subscriptions
- notify subscribers when topics receive new posts
- cover subscriptions with automated tests

## Testing
- `php tests/forum_attachments.php`
- `php tests/forum_bans.php`
- `php tests/forum_delete.php`
- `php tests/forum_mod_dashboard.php`
- `php tests/forum_mod_log.php`
- `php tests/forum_notifications.php`
- `php tests/forum_permissions.php`
- `php tests/forum_posts.php`
- `php tests/forum_public.php`
- `php tests/forum_reports.php`
- `php tests/forum_search.php`
- `php tests/forum_subscriptions.php`
- `php tests/forum_topics.php`
- `php tests/forum_word_filter.php`
- `php tests/messages_pm.php`


------
https://chatgpt.com/codex/tasks/task_e_68954cd1f1308321b6aa9a424a8f999f