### PR TITLE
Escape profile bio and sanitize layout CSS output

### DIFF
--- a/public/profile.php
+++ b/public/profile.php
@@ -483,16 +483,16 @@ $statusInfo = fetchUserStatus($profileId);
                         <div class="inner">
                             <div class="section">
                                 <p itemprop="description">
-                                    <?= $userInfo['bio']; ?>
-                                    
-                                    
+                                    <?= htmlspecialchars($userInfo['bio'], ENT_QUOTES, 'UTF-8'); ?>
+
+
                                     <!-- USER STYLES -->
                                     <?php
                                     $stmt = $conn->prepare("SELECT * FROM `users` WHERE id = :id");
                                     $stmt->execute(array(':id' => $_GET['id']));
 
                                     while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-                                        echo $row['css'];
+                                        echo validateLayoutHTML($row['css']);
                                     }
                                     ?>
                                 </p>


### PR DESCRIPTION
## Summary
- Escape user biography output with `htmlspecialchars` to prevent XSS.
- Sanitize and render profile CSS using `validateLayoutHTML` for safer layout styling.

## Testing
- `php -l public/profile.php`


------
https://chatgpt.com/codex/tasks/task_e_6895728b40d08321becf2f22ddbddb17