### PR TITLE
Add CSRF protection to forms

### DIFF
--- a/admin/email.php
+++ b/admin/email.php
@@ -23,6 +23,7 @@ require("header.php");
             <h1>Email Settings</h1>
             <p>Configure your site's email settings here</p>
             <form method="post" class="ctrl-enter-submit">
+    <?= csrf_token_input(); ?>
                 <button type="submit" name="submit">Save All</button>
                 <br>
                 <label for="category_smtp_host">

--- a/admin/forum/categories.php
+++ b/admin/forum/categories.php
@@ -86,6 +86,7 @@ if (isset($_GET['edit'])) {
                 <td>
                     <a href="categories.php?edit=<?= $cat['id'] ?>">Edit</a>
                     <form method="post" style="display:inline" onsubmit="return confirm('Delete this category?');">
+    <?= csrf_token_input(); ?>
                         <input type="hidden" name="id" value="<?= $cat['id'] ?>">
                         <button type="submit" name="delete">Delete</button>
                     </form>
@@ -98,6 +99,7 @@ if (isset($_GET['edit'])) {
     <?php if ($editCategory): ?>
     <h2>Edit Category</h2>
     <form method="post" class="ctrl-enter-submit">
+    <?= csrf_token_input(); ?>
         <input type="hidden" name="id" value="<?= $editCategory['id'] ?>">
         <label>Name: <input type="text" name="name" value="<?= htmlspecialchars($editCategory['name']) ?>" required></label>
         <label>Position: <input type="number" name="position" value="<?= $editCategory['position'] ?>" required></label>
@@ -107,6 +109,7 @@ if (isset($_GET['edit'])) {
 
     <h2>Add Category</h2>
     <form method="post" class="ctrl-enter-submit">
+    <?= csrf_token_input(); ?>
         <label>Name: <input type="text" name="name" required></label>
         <label>Position: <input type="number" name="position" value="<?= count($categories) + 1 ?>" required></label>
         <button type="submit" name="add">Add</button>

--- a/admin/forum/forums.php
+++ b/admin/forum/forums.php
@@ -136,7 +136,8 @@ function renderForumRows(array $forumsByParent, $parentId = 0, $level = 0) {
         echo '<td>';
         echo '<a href="forums.php?edit=' . $forum['id'] . '">Edit</a> ';
         echo '<a href="permissions.php?forum_id=' . $forum['id'] . '">Permissions</a> ';
-        echo '<form method="post" style="display:inline" onsubmit="return confirm(\'Delete this forum and its subforums?\');">';
+        echo '<form method="post" style="display:inline" onsubmit="return confirm(\'Delete this forum and its subforums?\');">
+    <?= csrf_token_input(); ?>';
         echo '<input type="hidden" name="id" value="' . $forum['id'] . '">';
         echo '<button type="submit" name="delete">Delete</button>';
         echo '</form>';
@@ -176,6 +177,7 @@ function renderForumRows(array $forumsByParent, $parentId = 0, $level = 0) {
     <?php if ($editForum): ?>
     <h2>Edit Forum</h2>
     <form method="post" class="ctrl-enter-submit">
+    <?= csrf_token_input(); ?>
         <input type="hidden" name="id" value="<?= $editForum['id'] ?>">
         <label>Name: <input type="text" name="name" value="<?= htmlspecialchars($editForum['name']) ?>" required></label>
         <label>Description:<br><textarea name="description" required><?= htmlspecialchars($editForum['description']) ?></textarea></label>
@@ -202,6 +204,7 @@ function renderForumRows(array $forumsByParent, $parentId = 0, $level = 0) {
 
     <h2>Add Forum</h2>
     <form method="post" class="ctrl-enter-submit">
+    <?= csrf_token_input(); ?>
         <label>Name: <input type="text" name="name" required></label>
         <label>Description:<br><textarea name="description" required></textarea></label>
         <label>Category:

--- a/admin/forum/global_mods.php
+++ b/admin/forum/global_mods.php
@@ -84,6 +84,7 @@ $mods = $modsStmt->fetchAll(PDO::FETCH_ASSOC);
                     <td>
                         <?php if ($mod['rank'] == 1): ?>
                         <form method="post" style="display:inline" onsubmit="return confirm('Demote this user?');">
+    <?= csrf_token_input(); ?>
                             <input type="hidden" name="user_id" value="<?= $mod['id'] ?>">
                             <button type="submit" name="demote">Demote</button>
                         </form>
@@ -98,6 +99,7 @@ $mods = $modsStmt->fetchAll(PDO::FETCH_ASSOC);
 
     <h2>Add Global Moderator</h2>
     <form method="post">
+    <?= csrf_token_input(); ?>
         <input type="text" name="user" placeholder="Username or ID">
         <button type="submit" name="add">Promote</button>
     </form>

--- a/admin/forum/moderators.php
+++ b/admin/forum/moderators.php
@@ -86,6 +86,7 @@ $forums = $conn->query('SELECT id, name FROM forums ORDER BY position ASC')->fet
                         <?php foreach ($mods as $mod): ?>
                             <?= htmlspecialchars($mod['username']) ?> (ID: <?= $mod['user_id'] ?>)
                             <form method="post" style="display:inline">
+    <?= csrf_token_input(); ?>
                                 <input type="hidden" name="forum_id" value="<?= $forum['id'] ?>">
                                 <input type="hidden" name="user_id" value="<?= $mod['user_id'] ?>">
                                 <button type="submit" name="remove">Remove</button>
@@ -95,6 +96,7 @@ $forums = $conn->query('SELECT id, name FROM forums ORDER BY position ASC')->fet
                 </td>
                 <td>
                     <form method="post">
+    <?= csrf_token_input(); ?>
                         <input type="hidden" name="forum_id" value="<?= $forum['id'] ?>">
                         <input type="text" name="user" placeholder="Username or ID">
                         <button type="submit" name="add">Add</button>

--- a/admin/forum/permissions.php
+++ b/admin/forum/permissions.php
@@ -55,6 +55,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <div class="simple-container">
     <h1>Permissions for <?= htmlspecialchars($forum['name']) ?></h1>
     <form method="post">
+    <?= csrf_token_input(); ?>
         <input type="hidden" name="forum_id" value="<?= $forumId ?>">
         <table class="bulletin-table">
             <thead>

--- a/admin/index.php
+++ b/admin/index.php
@@ -57,6 +57,7 @@ $postCount = $conn->query('SELECT COUNT(*) FROM blogs')->fetchColumn();
         <h1>General Settings</h1>
         <p>Here you can change general site-wide settings</p>
         <form method="post" class="ctrl-enter-submit">
+    <?= csrf_token_input(); ?>
             <button type="submit" name="submit">Save All</button>
             <br>
             <label for="category_status">

--- a/admin/login.php
+++ b/admin/login.php
@@ -41,6 +41,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['action'])) {
                     <!-- Login/Signup Form -->
                     <h4>Please login or signup to continue.</h4>
                     <form action="" method="post" name="theForm" id="theForm">
+    <?= csrf_token_input(); ?>
                         <input name="client_id" type="hidden" value="web">
                         <table>
                             <tbody>

--- a/admin/modify_user.php
+++ b/admin/modify_user.php
@@ -53,6 +53,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <?php endif; ?>
 
     <form method="post" action="">
+    <?= csrf_token_input(); ?>
         <h2>User Information</h2>
         <p>Username: <?php echo htmlspecialchars(fetchName($userId)); ?></p>
         <p>Email: <?php echo htmlspecialchars(fetchEmail($userId)); ?></p>

--- a/admin/users.php
+++ b/admin/users.php
@@ -101,6 +101,7 @@ th, td {
           </td>
           <td> 
             <form method="post" action="">
+    <?= csrf_token_input(); ?>
                 <input type="hidden" name="user_id" value="<?php echo $userId; ?>">
                 <?php if (!$isBanned): ?>
                     <button type="submit" name="ban_user">Ban</button>

--- a/core/helper.php
+++ b/core/helper.php
@@ -21,6 +21,28 @@ function admin_only() {
     }
 }
 
+function csrf_token() {
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+function csrf_token_input() {
+    return '<input type="hidden" name="csrf_token" value="' . htmlspecialchars(csrf_token(), ENT_QUOTES) . '">';
+}
+
+function csrf_verify() {
+    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        if (!isset($_POST['csrf_token'], $_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+            die('Invalid CSRF token');
+        }
+        unset($_SESSION['csrf_token']);
+    }
+}
+
+csrf_verify();
+
 function validateContentHTML($validate) {
     // Whitelisted tags
     $allowedTags = '<a><b><big><blockquote><blink><br><center><code><del><details><div><em><font><h1><h2><h3><h4><h5><h6><hr><i><iframe><img><li><mark><marquee><ol><p><pre><small><span><strong><style><sub><summary><sup><table><td><th><time><tr><u><ul>';

--- a/public/addcomment.php
+++ b/public/addcomment.php
@@ -33,6 +33,7 @@ if (isset($_SESSION['user'], $_POST['submit'], $_POST['comment']) && !empty($_PO
     <h2>Add Comment</h2>
     <p>Be nice.</p>
         <form method="post" class="ctrl-enter-submit">
+    <?= csrf_token_input(); ?>
       <label for="comment"><h4>Your Comment:</h4></label>
       <textarea class="big_textarea" id="comment" name="comment" required autofocus></textarea>
       <button type="submit" name="submit">Add Comment</button>

--- a/public/addfavorite.php
+++ b/public/addfavorite.php
@@ -21,8 +21,10 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST["submit"])) {
   <h1><img src="static/icons/award_star_add.png" class="icon" aria-hidden="true" loading="lazy" alt="Add to favorites icon"> Add Favorite</h1>
       <p>Do you want to add this user to your Favorites?</p>
     <form method="post">
+    <?= csrf_token_input(); ?>
       <button type="submit" name="submit">Add to Favorites</button>
       <form>
+    <?= csrf_token_input(); ?>
             <a href="profile.php?id=<?= $profileId ?>"><button type="button">Go Back</button></a>
 </div>
 

--- a/public/blog/addcomment.php
+++ b/public/blog/addcomment.php
@@ -39,6 +39,7 @@ if (isset($_SESSION['user'], $_POST['submit'], $_POST['comment']) && !empty($_PO
     <h2>Add Comment</h2>
     <p>Be nice.</p>
         <form method="post" class="ctrl-enter-submit">
+    <?= csrf_token_input(); ?>
       <label for="comment"><h4>Your Comment:</h4></label>
       <textarea class="big_textarea" id="comment" name="comment" required autofocus></textarea>
       <button type="submit" name="submit">Add Comment</button>

--- a/public/blog/deletecomment.php
+++ b/public/blog/deletecomment.php
@@ -41,6 +41,7 @@ if (!$isUserAuthor) {
 <div class="simple-container">
     <h1>Confirm Deletion</h1>
     <form method="POST" action="">
+    <?= csrf_token_input(); ?>
         <p>Type "DELETE" to confirm the deletion of the comment:</p>
         <input type="text" name="confirmation" required>
         <button type="submit" name="submit">Delete</button>

--- a/public/blog/deletepost.php
+++ b/public/blog/deletepost.php
@@ -40,6 +40,7 @@ if (!$isUserAuthor) {
 <div class="simple-container">
     <h1>Confirm Deletion</h1>
     <form method="POST" action="">
+    <?= csrf_token_input(); ?>
         <p>Type "DELETE" to confirm the deletion of the blog entry:</p>
         <input type="text" name="confirmation" required>
         <button type="submit" name="submit">Delete</button>

--- a/public/blog/editpost.php
+++ b/public/blog/editpost.php
@@ -69,6 +69,7 @@ if (!$isUserAuthor) {
           <br>
 
           <form method="post" class="ctrl-enter-submit">
+    <?= csrf_token_input(); ?>
             <label for="subject">Subject:</label>
             <input type="text" id="subject" name="subject" autocomplete="off" value="<?= $blogEntry['title'] ?>"
               required>

--- a/public/blog/newpost.php
+++ b/public/blog/newpost.php
@@ -62,6 +62,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['submit'])) {
           <br>
 
           <form method="post" class="ctrl-enter-submit">
+    <?= csrf_token_input(); ?>
             <label for="subject">Subject:</label>
             <input type="text" id="subject" name="subject" autocomplete="off" value="" required>
 

--- a/public/bulletins/addcomment.php
+++ b/public/bulletins/addcomment.php
@@ -41,6 +41,7 @@ if (isset($_SESSION['user'], $_POST['submit'], $_POST['comment']) && !empty($_PO
     <h2>Add Comment</h2>
     <p>Be nice.</p>
         <form method="post" class="ctrl-enter-submit">
+    <?= csrf_token_input(); ?>
       <label for="comment"><h4>Your Comment:</h4></label>
       <textarea class="big_textarea" id="comment" name="comment" required autofocus></textarea>
       <button type="submit" name="submit">Add Comment</button>

--- a/public/bulletins/createbulletin.php
+++ b/public/bulletins/createbulletin.php
@@ -50,6 +50,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['submit'])) {
     <br>
     
     <form method="post" class="ctrl-enter-submit">
+    <?= csrf_token_input(); ?>
       <label for="subject">Subject:</label>
       <input type="text" id="subject" name="subject" autocomplete="off" value="" required>
 

--- a/public/bulletins/deletecomment.php
+++ b/public/bulletins/deletecomment.php
@@ -41,6 +41,7 @@ if (!$isUserAuthor) {
 <div class="simple-container">
     <h1>Confirm Deletion</h1>
     <form method="POST" action="">
+    <?= csrf_token_input(); ?>
         <p>Type "DELETE" to confirm the deletion of the comment:</p>
         <input type="text" name="confirmation" required>
         <button type="submit" name="submit">Delete</button>

--- a/public/deletecomment.php
+++ b/public/deletecomment.php
@@ -41,6 +41,7 @@ if (!$isUserAuthor) {
 <div class="simple-container">
     <h1>Confirm Deletion</h1>
     <form method="POST" action="">
+    <?= csrf_token_input(); ?>
         <p>Type "DELETE" to confirm the deletion of the comment:</p>
         <input type="text" name="confirmation" required>
         <button type="submit" name="submit">Delete</button>

--- a/public/editstatus.php
+++ b/public/editstatus.php
@@ -44,6 +44,7 @@ $you = $statusInfo['you'];
         <h1>Edit Your Status</h1>
         <p>All fields are optional and can be left empty if you want.</p>
         <form method="post" class="ctrl-enter-submit">
+    <?= csrf_token_input(); ?>
             <button type="submit" name="submit">Save All</button>
             <br>
             <label for="category_status">

--- a/public/forum/edit_post.php
+++ b/public/forum/edit_post.php
@@ -50,6 +50,7 @@ $pageCSS = "../static/css/forum.css";
     <h1>Edit Post</h1>
     <?php if ($error): ?><div class="alert"><?= htmlspecialchars($error) ?></div><?php endif; ?>
     <form method="post" enctype="multipart/form-data">
+    <?= csrf_token_input(); ?>
         <textarea name="body" aria-label="Post message"><?= htmlspecialchars($post['body']) ?></textarea>
         <input type="file" name="attachment" aria-label="Attachment">
         <?php foreach ($attachments as $att): ?>

--- a/public/forum/mod/ban_user.php
+++ b/public/forum/mod/ban_user.php
@@ -25,6 +25,7 @@ $pageCSS = "../../static/css/forum.css";
 <div class="simple-container">
     <h1>Ban User</h1>
     <form method="post">
+    <?= csrf_token_input(); ?>
         <label>User ID: <input type="number" name="user_id" required></label><br>
         <label>Ban Until (YYYY-MM-DD HH:MM:SS): <input type="text" name="ban_until"></label><br>
         <button type="submit">Submit</button>

--- a/public/forum/mod/reports.php
+++ b/public/forum/mod/reports.php
@@ -35,21 +35,25 @@ $pageCSS = "../../static/css/forum.css";
             <td><?= $r['reporter_id'] ?></td>
             <td>
                 <form method="post" style="display:inline">
+    <?= csrf_token_input(); ?>
                     <input type="hidden" name="report_id" value="<?= $r['id'] ?>">
                     <input type="hidden" name="action" value="keep">
                     <button type="submit">Keep</button>
                 </form>
                 <form method="post" style="display:inline">
+    <?= csrf_token_input(); ?>
                     <input type="hidden" name="report_id" value="<?= $r['id'] ?>">
                     <input type="hidden" name="action" value="edit">
                     <button type="submit">Edit</button>
                 </form>
                 <form method="post" style="display:inline">
+    <?= csrf_token_input(); ?>
                     <input type="hidden" name="report_id" value="<?= $r['id'] ?>">
                     <input type="hidden" name="action" value="delete">
                     <button type="submit">Delete</button>
                 </form>
                 <form method="post" style="display:inline">
+    <?= csrf_token_input(); ?>
                     <input type="hidden" name="report_id" value="<?= $r['id'] ?>">
                     <input type="hidden" name="action" value="ban">
                     <button type="submit">Ban</button>

--- a/public/forum/mod/word_filter.php
+++ b/public/forum/mod/word_filter.php
@@ -26,6 +26,7 @@ $pageCSS = "../../static/css/forum.css";
 <div class="simple-container">
     <h1>Word Filter</h1>
     <form method="post">
+    <?= csrf_token_input(); ?>
         <input type="hidden" name="action" value="add">
         <input type="text" name="word" required>
         <button type="submit">Add</button>
@@ -37,6 +38,7 @@ $pageCSS = "../../static/css/forum.css";
     <?php foreach ($words as $w): ?>
         <li><?= htmlspecialchars($w) ?>
             <form method="post" style="display:inline">
+    <?= csrf_token_input(); ?>
                 <input type="hidden" name="action" value="delete">
                 <input type="hidden" name="word" value="<?= htmlspecialchars($w) ?>">
                 <button type="submit">Remove</button>

--- a/public/forum/new_post.php
+++ b/public/forum/new_post.php
@@ -43,6 +43,7 @@ $pageCSS = "../static/css/forum.css";
     <?php if ($error): ?><div class="alert"><?= htmlspecialchars($error) ?></div><?php endif; ?>
     <?php if ($can_post): ?>
     <form method="post" enctype="multipart/form-data">
+    <?= csrf_token_input(); ?>
         <textarea name="body" aria-label="Post message"></textarea>
         <input type="file" name="attachment" aria-label="Attachment">
         <button type="submit" aria-label="Submit reply" role="button">Post</button>

--- a/public/forum/post.php
+++ b/public/forum/post.php
@@ -120,10 +120,12 @@ $pageCSS = "../static/css/forum.css";
     <?php if ($can_moderate): ?>
     <div class="mod-actions">
         <form method="post" style="display:inline">
+    <?= csrf_token_input(); ?>
             <input type="hidden" name="action" value="<?= $topic['locked'] ? 'unlock' : 'lock' ?>">
             <button type="submit" aria-label="<?= $topic['locked'] ? 'Unlock topic' : 'Lock topic' ?>" role="button"><?= $topic['locked'] ? 'Unlock' : 'Lock' ?></button>
         </form>
         <form method="post" style="display:inline">
+    <?= csrf_token_input(); ?>
             <input type="hidden" name="action" value="<?= $topic['sticky'] ? 'unsticky' : 'sticky' ?>">
             <button type="submit" aria-label="<?= $topic['sticky'] ? 'Unsticky topic' : 'Sticky topic' ?>" role="button"><?= $topic['sticky'] ? 'Unsticky' : 'Sticky' ?></button>
         </form>
@@ -134,6 +136,7 @@ $pageCSS = "../static/css/forum.css";
         <h2><?= htmlspecialchars($poll['question']) ?></h2>
         <?php if ($userVote === false && isset($_SESSION['userId'])): ?>
         <form method="post">
+    <?= csrf_token_input(); ?>
             <?php $opts = json_decode($poll['options'], true) ?: []; foreach ($opts as $i => $opt): ?>
             <div><label><input type="radio" name="poll_vote" value="<?= $i ?>"> <?= htmlspecialchars($opt) ?></label></div>
             <?php endforeach; ?>
@@ -184,6 +187,7 @@ $pageCSS = "../static/css/forum.css";
 <div class="reactions">
 <?php foreach ($availableReactions as $react): $count = $reactionCounts[$react] ?? 0; ?>
     <form method="post" style="display:inline">
+    <?= csrf_token_input(); ?>
         <input type="hidden" name="reaction_action" value="add">
         <input type="hidden" name="post_id" value="<?= $post['id'] ?>">
         <input type="hidden" name="reaction" value="<?= $react ?>">
@@ -192,6 +196,7 @@ $pageCSS = "../static/css/forum.css";
 <?php endforeach; ?>
 <?php if ($userReaction): ?>
     <form method="post" style="display:inline">
+    <?= csrf_token_input(); ?>
         <input type="hidden" name="reaction_action" value="remove">
         <input type="hidden" name="post_id" value="<?= $post['id'] ?>">
         <button type="submit" role="button">Remove (<?= htmlspecialchars($userReaction) ?>)</button>
@@ -203,6 +208,7 @@ $pageCSS = "../static/css/forum.css";
                     <?php endif; ?>
                       <?php if (isset($_SESSION['userId'])): ?>
                       <form method="post" action="report.php" style="display:inline">
+    <?= csrf_token_input(); ?>
                           <input type="hidden" name="type" value="post">
                           <input type="hidden" name="id" value="<?= $post['id'] ?>">
                           <button type="submit" role="button">Report</button>
@@ -211,6 +217,7 @@ $pageCSS = "../static/css/forum.css";
                 <?php endif; ?>
                 <?php if ($can_moderate): ?>
                     <form method="post" style="display:inline">
+    <?= csrf_token_input(); ?>
                         <input type="hidden" name="post_id" value="<?= $post['id'] ?>">
                         <input type="hidden" name="action" value="<?= $post['deleted'] ? 'restore_post' : 'delete_post' ?>">
                         <button type="submit" aria-label="<?= $post['deleted'] ? 'Restore post' : 'Delete post' ?>" role="button"><?= $post['deleted'] ? 'Restore' : 'Delete' ?></button>
@@ -227,6 +234,7 @@ $pageCSS = "../static/css/forum.css";
 
     <?php if (!$topic['locked'] && $can_post): ?>
     <form method="post">
+    <?= csrf_token_input(); ?>
         <textarea name="body" aria-label="Post message"><?= htmlspecialchars($prefill) ?></textarea>
         <button type="submit" aria-label="Submit reply" role="button">Post</button>
     </form>

--- a/public/forum/report.php
+++ b/public/forum/report.php
@@ -27,6 +27,7 @@ $pageCSS = "../static/css/forum.css";
 <div class="simple-container">
     <h1>Report</h1>
     <form method="post">
+    <?= csrf_token_input(); ?>
         <input type="hidden" name="type" value="<?= htmlspecialchars($type) ?>">
         <input type="hidden" name="id" value="<?= $id ?>">
         <textarea name="reason" aria-label="Report reason"></textarea>

--- a/public/forum/settings.php
+++ b/public/forum/settings.php
@@ -38,6 +38,7 @@ require("../header.php");
     <p><?= htmlspecialchars($message) ?></p>
     <?php endif; ?>
     <form method="post">
+    <?= csrf_token_input(); ?>
         <p>
             <label>Background Image URL:<br>
                 <input type="text" name="background_url" value="<?= htmlspecialchars($settings['background_image_url'] ?? '') ?>">

--- a/public/forum/topic.php
+++ b/public/forum/topic.php
@@ -100,11 +100,13 @@ $pageCSS = "../static/css/forum.css";
             <td><a href="post.php?id=<?= $linkId ?>" aria-label="View topic <?= htmlspecialchars($t['title']) ?>" role="link"><?= htmlspecialchars($t['title']) ?></a>
                 <?php if (isset($_SESSION['userId'])): ?>
                 <form method="post" action="report.php" style="display:inline">
+    <?= csrf_token_input(); ?>
                     <input type="hidden" name="type" value="topic">
                     <input type="hidden" name="id" value="<?= $t['id'] ?>">
                     <button type="submit" role="button">Report</button>
                 </form>
                 <form method="post" style="display:inline">
+    <?= csrf_token_input(); ?>
                     <input type="hidden" name="subscribe_topic" value="<?= $t['id'] ?>">
                     <button type="submit" role="button"><?= in_array($t['id'], $subscribed) ? 'Unsubscribe' : 'Subscribe' ?></button>
                 </form>
@@ -115,11 +117,13 @@ $pageCSS = "../static/css/forum.css";
             <?php if ($can_moderate): ?>
             <td>
                 <form method="post" style="display:inline">
+    <?= csrf_token_input(); ?>
                     <input type="hidden" name="topic_id" value="<?= $t['id'] ?>">
                     <input type="hidden" name="action" value="<?= $t['locked'] ? 'unlock' : 'lock' ?>">
                     <button type="submit" aria-label="<?= $t['locked'] ? 'Unlock topic' : 'Lock topic' ?>" role="button"><?= $t['locked'] ? 'Unlock' : 'Lock' ?></button>
                 </form>
                 <form method="post" style="display:inline">
+    <?= csrf_token_input(); ?>
                     <input type="hidden" name="topic_id" value="<?= $t['id'] ?>">
                     <input type="hidden" name="action" value="<?= $t['sticky'] ? 'unsticky' : 'sticky' ?>">
                     <button type="submit" aria-label="<?= $t['sticky'] ? 'Unsticky topic' : 'Sticky topic' ?>" role="button"><?= $t['sticky'] ? 'Unsticky' : 'Sticky' ?></button>
@@ -137,6 +141,7 @@ $pageCSS = "../static/css/forum.css";
     <?php if ($can_post): ?>
     <h2>New Topic</h2>
     <form method="post">
+    <?= csrf_token_input(); ?>
         <input type="text" name="title" placeholder="Title" aria-label="Topic title">
         <textarea name="body" aria-label="Topic message"></textarea>
         <h3>Poll (optional)</h3>

--- a/public/groups/newgroup.php
+++ b/public/groups/newgroup.php
@@ -31,6 +31,7 @@
                 }
             ?>
             <form method="post" enctype="multipart/form-data">
+    <?= csrf_token_input(); ?>
                 <input required placeholder="Name" size="90" type="text" name="groupname"><br>
 				<textarea required rows="10" cols="68" placeholder="Description" name="desc"></textarea><br>
 				<input name="submit" type="submit" value="Create"> <small>max limit: 500 characters</small>

--- a/public/groups/viewgroup.php
+++ b/public/groups/viewgroup.php
@@ -47,6 +47,7 @@
                 <center>Comments</center>
             </div>
             <form method="post" enctype="multipart/form-data">
+    <?= csrf_token_input(); ?>
 				<textarea required rows="5" cols="80" placeholder="Comment" name="comment"></textarea><br>
 				<input name="submit" type="submit" value="Post"> <small>max limit: 500 characters</small>
             </form>

--- a/public/home.php
+++ b/public/home.php
@@ -262,6 +262,7 @@ $bulletins = fetchAllFriendBulletins($userId, 5);
                                             <td>
                                                 <p><b>Friend Request</b></p>
                                                 <form method="post">
+    <?= csrf_token_input(); ?>
                                                     <input type="hidden" name="type" value="friend-request">
                                                     <input type="hidden" name="request_id"
                                                         value="<?= htmlspecialchars($request['id']) ?>">

--- a/public/index.php
+++ b/public/index.php
@@ -142,6 +142,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['action'])) {
                         <!-- Login/Signup Form -->
                         <h4>Member Login/Signup</h4>
                         <form action="" method="post" name="theForm" id="theForm">
+    <?= csrf_token_input(); ?>
                             <input name="client_id" type="hidden" value="web">
                             <table>
                                 <tbody>

--- a/public/install.php
+++ b/public/install.php
@@ -1,4 +1,6 @@
 <?php
+session_start();
+require_once("../core/helper.php");
 // Check if config already exists
 if (file_exists("../core/config.php")) {
     header("Location: index.php");
@@ -280,6 +282,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     <body>
         <h1>AnySpace Installation</h1>
         <form method="POST">
+    <?= csrf_token_input(); ?>
             <div class="section">
                 <h2>Database Configuration</h2>
                 <div class="form-group">

--- a/public/login.php
+++ b/public/login.php
@@ -37,6 +37,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['action'])) {
                     <!-- Login/Signup Form -->
                     <h4>Please login or signup to continue.</h4>
                     <form action="" method="post" name="theForm" id="theForm">
+    <?= csrf_token_input(); ?>
                         <input name="client_id" type="hidden" value="web">
                         <table>
                             <tbody>

--- a/public/manage.php
+++ b/public/manage.php
@@ -82,6 +82,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
                     <h1>Change Name:</h1>
                     <br>
                     <form method="post" enctype="multipart/form-data">
+    <?= csrf_token_input(); ?>
                         <input size="77" type="text" name="newUsername" placeholder="New Username"
                             value="<?php echo htmlspecialchars($_SESSION['user']); ?>"><br>
                         <input name="usernameset" type="submit" value="Change Name" style="max-width: 20%;"> <small>max: 50
@@ -94,6 +95,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
                     <h1>Profile Picture & Song:</h1>
                     <br>
                     <form method="post" enctype="multipart/form-data">
+    <?= csrf_token_input(); ?>
                         <small>Select photo:</small>
                         <input type="file" name="fileToUpload" id="fileToUpload">
                         <input type="submit" value="Upload Image" name="submit">
@@ -102,6 +104,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
                     <hr style="max-width: 80%;">
                     <br>
                     <form method="post" enctype="multipart/form-data">
+    <?= csrf_token_input(); ?>
                         <small>Select song:</small>
                         <input type="file" name="fileToUpload" id="fileToUpload">
                         <input type="submit" value="Upload Song" name="photoset">
@@ -112,6 +115,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
                     <h1>Bio:</h1>
                     <br>
                     <form method="post" enctype="multipart/form-data">
+    <?= csrf_token_input(); ?>
                         <textarea required cols="58" placeholder="Bio" name="bio"><?php echo $bio; ?></textarea><br>
                         <input name="bioset" type="submit" value="Set"> <small>max limit: 500 characters | supports
                             bbcode</small>
@@ -120,6 +124,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
                     <h1>Interests:</h1>
                     <br>
                     <form method="post" enctype="multipart/form-data">
+    <?= csrf_token_input(); ?>
                         <label for="general">General:</label>
                         <input type="text" id="general" name="interests[General]"
                             value="<?php echo htmlspecialchars($interests['General']); ?>">
@@ -160,6 +165,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
                     <small>what you would normally paste into the 'Blurbs' section. Include HTML tags.</small>
                     <br>
                     <form accept-charset="UTF-8" method="post" enctype="multipart/form-data">
+    <?= csrf_token_input(); ?>
                         <textarea required rows="15" cols="58" placeholder="Your code"
                             name="css"><?php echo $css; ?></textarea><br>
                         <input name="cssset" type="submit" value="Set"> <small>max limit: None</small>

--- a/public/messages/compose.php
+++ b/public/messages/compose.php
@@ -1,10 +1,6 @@
 <?php
 require("../../core/conn.php");
 require_once("../../core/settings.php");
- 97xjcb-codex/create-messages-table-and-related-features
-require_once("../../core/helper.php");
-=======
- main
 require("../../core/messages/pm.php");
 
 login_check();
@@ -37,6 +33,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <p><?= htmlspecialchars($message) ?></p>
     <?php endif; ?>
     <form method="post">
+    <?= csrf_token_input(); ?>
         <p><label>To: <input type="text" name="to" required></label></p>
         <p><label>Subject: <input type="text" name="subject" required></label></p>
         <p><label>Message:<br>
@@ -46,4 +43,3 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </div>
 
 <?php require("../footer.php"); ?>
-

--- a/public/register.php
+++ b/public/register.php
@@ -87,6 +87,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
                 <?php if ($message)
                     echo $message; ?>
                 <form action="" method="post">
+    <?= csrf_token_input(); ?>
                     <input required placeholder="Username" type="text" name="username"><br>
                     <input required placeholder="E-Mail" type="email" name="email"><br>
                     <input required placeholder="Password" type="password" name="password"><br>

--- a/public/requests.php
+++ b/public/requests.php
@@ -49,6 +49,7 @@ $acceptedFriends = array_merge(
                                     <?= count($pendingReceived); ?>
                                 </span> Open Friend Requests</b></p>
                         <form method="post">
+    <?= csrf_token_input(); ?>
                             <input type="hidden" name="type" value="accept_all_requests">
                             <button type="submit" name="submit">Accept All Requests</button>
                         </form>
@@ -81,6 +82,7 @@ $acceptedFriends = array_merge(
                                             <td>
                                                 <p><b>Friend Request</b></p>
                                                 <form method="post">
+    <?= csrf_token_input(); ?>
                                                     <input type="hidden" name="type" value="friend-request">
                                                     <input type="hidden" name="request_id"
                                                         value="<?= htmlspecialchars($request['id']); ?>">
@@ -140,6 +142,7 @@ $acceptedFriends = array_merge(
                                             <td>
                                                 <p><b>Sent Friend Request</b></p>
                                                 <form method="post">
+    <?= csrf_token_input(); ?>
                                                     <input type="hidden" name="type" value="friend-request">
                                                     <input type="hidden" name="request_id"
                                                         value="<?= htmlspecialchars($request['id']); ?>">

--- a/public/settings.php
+++ b/public/settings.php
@@ -39,6 +39,7 @@ if (isset($_POST['password-old']) && isset($_POST['password-new']) && isset($_PO
 <div class="simple-container">
   <h1>Account Settings</h1>
     <form method="post" class="ctrl-enter-submit">
+    <?= csrf_token_input(); ?>
     <div class="setting-section">
       <div class="heading">
         <h4>Basic Details</h4>

--- a/public/unfriend.php
+++ b/public/unfriend.php
@@ -35,6 +35,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['submit'])) {
 <div class="simple-container">
     <h1>Are you sure you want to unfriend <?= fetchName($friendId); ?>?</h1>
     <form method="POST" action="">
+    <?= csrf_token_input(); ?>
         <p>Type "DELETE" to remove friend:</p>
         <input type="text" name="confirmation" required>
         <button type="submit" name="submit">Delete</button>


### PR DESCRIPTION
## Summary
- add CSRF token generator and verifier
- inject hidden token fields into form templates across the site
- validate tokens on POST requests

## Testing
- `php -l admin/email.php admin/forum/categories.php admin/forum/forums.php admin/forum/global_mods.php admin/forum/moderators.php admin/forum/permissions.php admin/index.php admin/login.php admin/modify_user.php admin/users.php core/helper.php public/addcomment.php public/addfavorite.php public/blog/addcomment.php public/blog/deletecomment.php public/blog/deletepost.php public/blog/editpost.php public/blog/newpost.php public/bulletins/addcomment.php public/bulletins/createbulletin.php public/bulletins/deletecomment.php public/deletecomment.php public/editstatus.php public/forum/edit_post.php public/forum/mod/ban_user.php public/forum/mod/reports.php public/forum/mod/word_filter.php public/forum/new_post.php public/forum/post.php public/forum/report.php public/forum/settings.php public/forum/topic.php public/groups/newgroup.php public/groups/viewgroup.php public/home.php public/index.php public/install.php public/login.php public/manage.php public/messages/compose.php public/register.php public/requests.php public/settings.php public/unfriend.php`


------
https://chatgpt.com/codex/tasks/task_e_689586ae331c8321b1faf1e326a61ce3