### PR TITLE
Add Content Security Policy headers

### DIFF
--- a/admin/header.php
+++ b/admin/header.php
@@ -1,3 +1,6 @@
+<?php
+header("Content-Security-Policy: default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline';");
+?>
 <!DOCTYPE html>
 <html>
 

--- a/public/blog/blog-header.php
+++ b/public/blog/blog-header.php
@@ -1,3 +1,6 @@
+<?php
+header("Content-Security-Policy: default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline';");
+?>
 <!DOCTYPE html>
 <html>
 

--- a/public/bulletins/bulletins-header.php
+++ b/public/bulletins/bulletins-header.php
@@ -1,3 +1,6 @@
+<?php
+header("Content-Security-Policy: default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline';");
+?>
 <!DOCTYPE html>
 <html>
 

--- a/public/header.php
+++ b/public/header.php
@@ -1,3 +1,6 @@
+<?php
+header("Content-Security-Policy: default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline';");
+?>
 <!DOCTYPE html>
 <html>
 


### PR DESCRIPTION
## Summary
- Send a basic Content-Security-Policy header from shared header includes.
- Apply the policy across public, blog, bulletins, and admin sections.

## Testing
- `php -l admin/header.php public/header.php public/blog/blog-header.php public/bulletins/bulletins-header.php`
- `for f in tests/*.php; do echo "Running $f"; php $f; echo; done`

------
https://chatgpt.com/codex/tasks/task_e_68958819b9e88321a1ea1f3f9f8c16e8