### PR TITLE
Refactor forum admin pages to use core helpers

### DIFF
--- a/admin/forum/categories.php
+++ b/admin/forum/categories.php
@@ -1,13 +1,10 @@
 <?php
 require("../../core/conn.php");
 require_once("../../core/settings.php");
-
-if (!isset($_SESSION['user'])) {
-    header("Location: ../login.php");
-    exit;
-}
+admin_only();
 
 require("../../core/config.php");
+require_once("../../core/forum/category.php");
 
 // Handle add, update, delete actions
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -19,8 +16,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             header('Location: categories.php?msg=' . urlencode('Name is required'));
             exit;
         }
-        $stmt = $conn->prepare('INSERT INTO forum_categories (name, position) VALUES (:name, :position)');
-        $stmt->execute([':name' => $name, ':position' => $position]);
+        forum_create_category($name, $position);
         header('Location: categories.php?msg=' . urlencode('Category added'));
         exit;
     }
@@ -34,8 +30,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             header('Location: categories.php?msg=' . urlencode('Invalid data'));
             exit;
         }
-        $stmt = $conn->prepare('UPDATE forum_categories SET name = :name, position = :position WHERE id = :id');
-        $stmt->execute([':name' => $name, ':position' => $position, ':id' => $id]);
+        forum_update_category($id, $name, $position);
         header('Location: categories.php?msg=' . urlencode('Category updated'));
         exit;
     }
@@ -44,8 +39,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['delete'])) {
         $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
         if ($id > 0) {
-            $stmt = $conn->prepare('DELETE FROM forum_categories WHERE id = :id');
-            $stmt->execute([':id' => $id]);
+            forum_delete_category($id);
             header('Location: categories.php?msg=' . urlencode('Category deleted'));
             exit;
         }
@@ -53,16 +47,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 // Fetch categories for display
-$stmt = $conn->query('SELECT * FROM forum_categories ORDER BY position ASC');
-$categories = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$categories = forum_get_categories();
 
 // Fetch category to edit if requested
 $editCategory = null;
 if (isset($_GET['edit'])) {
     $editId = (int)$_GET['edit'];
-    $stmt = $conn->prepare('SELECT * FROM forum_categories WHERE id = :id');
-    $stmt->execute([':id' => $editId]);
-    $editCategory = $stmt->fetch(PDO::FETCH_ASSOC);
+    $editCategory = forum_get_category($editId);
 }
 ?>
 <?php require("../header.php"); ?>

--- a/admin/forum/global_mods.php
+++ b/admin/forum/global_mods.php
@@ -1,12 +1,7 @@
 <?php
 require("../../core/conn.php");
 require_once("../../core/settings.php");
-
-login_check();
-if (!isset($_SESSION['userId']) || $_SESSION['userId'] != ADMIN_USER) {
-    header("Location: ../index.php?msg=" . urlencode('Admin access required'));
-    exit;
-}
+admin_only();
 
 require("../../core/config.php");
 

--- a/admin/forum/moderators.php
+++ b/admin/forum/moderators.php
@@ -1,12 +1,7 @@
 <?php
 require("../../core/conn.php");
 require_once("../../core/settings.php");
-
-login_check();
-if (!isset($_SESSION['userId']) || $_SESSION['userId'] != ADMIN_USER) {
-    header("Location: ../index.php?msg=" . urlencode('Admin access required'));
-    exit;
-}
+admin_only();
 
 require("../../core/config.php");
 

--- a/admin/forum/permissions.php
+++ b/admin/forum/permissions.php
@@ -1,11 +1,7 @@
 <?php
 require("../../core/conn.php");
 require_once("../../core/settings.php");
-
-if (!isset($_SESSION['user'])) {
-    header("Location: ../login.php");
-    exit;
-}
+admin_only();
 
 require("../../core/config.php");
 

--- a/core/forum/category.php
+++ b/core/forum/category.php
@@ -6,6 +6,14 @@ function forum_get_categories(): array {
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 
+function forum_get_category(int $id): ?array {
+    global $conn;
+    $stmt = $conn->prepare('SELECT id, name, position FROM forum_categories WHERE id = :id');
+    $stmt->execute([':id' => $id]);
+    $cat = $stmt->fetch(PDO::FETCH_ASSOC);
+    return $cat ?: null;
+}
+
 function forum_create_category(string $name, int $position = 0): int {
     global $conn;
     $stmt = $conn->prepare('INSERT INTO forum_categories (name, position) VALUES (:name, :pos)');

--- a/core/forum/forum.php
+++ b/core/forum/forum.php
@@ -1,8 +1,14 @@
 <?php
 
+function forum_get_all_forums(): array {
+    global $conn;
+    $stmt = $conn->query('SELECT * FROM forums ORDER BY position, id');
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
 function forum_get_forums_by_category(int $category_id): array {
     global $conn;
-    $stmt = $conn->prepare('SELECT id, name, description, position FROM forums WHERE category_id = :cid ORDER BY position, id');
+    $stmt = $conn->prepare('SELECT id, name, description, position, parent_forum_id FROM forums WHERE category_id = :cid ORDER BY position, id');
     $stmt->execute([':cid' => $category_id]);
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
@@ -15,21 +21,43 @@ function forum_get_forum(int $forum_id): ?array {
     return $forum ?: null;
 }
 
-function forum_create_forum(int $category_id, string $name, string $description, int $position = 0): int {
+function forum_create_forum(int $category_id, string $name, string $description, int $position = 0, ?int $parent_forum_id = null): int {
     global $conn;
-    $stmt = $conn->prepare('INSERT INTO forums (category_id, name, description, position) VALUES (:cid, :name, :descr, :pos)');
-    $stmt->execute([':cid' => $category_id, ':name' => $name, ':descr' => $description, ':pos' => $position]);
+    $stmt = $conn->prepare('INSERT INTO forums (category_id, parent_forum_id, name, description, position) VALUES (:cid, :pid, :name, :descr, :pos)');
+    $stmt->execute([':cid' => $category_id, ':pid' => $parent_forum_id, ':name' => $name, ':descr' => $description, ':pos' => $position]);
     return (int)$conn->lastInsertId();
 }
 
-function forum_update_forum(int $id, int $category_id, string $name, string $description, int $position): void {
+function forum_update_forum(int $id, int $category_id, string $name, string $description, int $position, ?int $parent_forum_id = null): void {
     global $conn;
-    $stmt = $conn->prepare('UPDATE forums SET category_id = :cid, name = :name, description = :descr, position = :pos WHERE id = :id');
-    $stmt->execute([':cid' => $category_id, ':name' => $name, ':descr' => $description, ':pos' => $position, ':id' => $id]);
+    $stmt = $conn->prepare('UPDATE forums SET category_id = :cid, parent_forum_id = :pid, name = :name, description = :descr, position = :pos WHERE id = :id');
+    $stmt->execute([':cid' => $category_id, ':pid' => $parent_forum_id, ':name' => $name, ':descr' => $description, ':pos' => $position, ':id' => $id]);
 }
 
 function forum_delete_forum(int $id): void {
     global $conn;
+
+    // delete child forums first
+    $childStmt = $conn->prepare('SELECT id FROM forums WHERE parent_forum_id = :id');
+    $childStmt->execute([':id' => $id]);
+    $children = $childStmt->fetchAll(PDO::FETCH_COLUMN);
+    foreach ($children as $childId) {
+        forum_delete_forum((int)$childId);
+    }
+
+    // remove posts and topics belonging to this forum
+    $postDel = $conn->prepare('DELETE FROM forum_posts WHERE topic_id IN (SELECT id FROM forum_topics WHERE forum_id = :id)');
+    $postDel->execute([':id' => $id]);
+    $topicDel = $conn->prepare('DELETE FROM forum_topics WHERE forum_id = :id');
+    $topicDel->execute([':id' => $id]);
+
+    // remove moderator assignments and permissions
+    $modDel = $conn->prepare('DELETE FROM forum_moderators WHERE forum_id = :id');
+    $modDel->execute([':id' => $id]);
+    $permDel = $conn->prepare('DELETE FROM forum_permissions WHERE forum_id = :id');
+    $permDel->execute([':id' => $id]);
+
+    // finally delete the forum itself
     $stmt = $conn->prepare('DELETE FROM forums WHERE id = :id');
     $stmt->execute([':id' => $id]);
 }

--- a/core/helper.php
+++ b/core/helper.php
@@ -6,6 +6,13 @@ function login_check() {
     }
 }
 
+function admin_only() {
+    if (!isset($_SESSION['userId']) || (defined('ADMIN_USER') && $_SESSION['userId'] != ADMIN_USER)) {
+        header("Location: /admin/login.php?msg=" . urlencode('Admin access required'));
+        exit;
+    }
+}
+
 function validateContentHTML($validate) {
     // Whitelisted tags
     $allowedTags = '<a><b><big><blockquote><blink><br><center><code><del><details><div><em><font><h1><h2><h3><h4><h5><h6><hr><i><iframe><img><li><mark><marquee><ol><p><pre><small><span><strong><style><sub><summary><sup><table><td><th><time><tr><u><ul>';

--- a/docs/forum/README.md
+++ b/docs/forum/README.md
@@ -1,0 +1,77 @@
+# AnySpace Forums
+
+This module provides a classic MySpace‑style discussion board with hierarchical categories, forums, and topics.  It follows AnySpace's modular patterns and reuses existing helpers for sessions and sanitization.
+
+## Directory Layout
+
+```
+admin/forum/           Admin pages for managing categories, forums, moderators, and permissions
+core/forum/            Reusable helpers for categories, forums, topics, posts, and permission checks
+public/forum/          (future) User‑facing forum pages
+tests/                 Regression tests for forum helpers
+```
+
+## Database Tables
+
+The schema extends `schema.sql` with tables below:
+
+| Table | Purpose |
+|-------|---------|
+| `forum_categories` | Top‑level containers for forums; ordered via `position` |
+| `forums` | Individual forums and subforums; reference a category and optional parent forum |
+| `forum_topics` | Discussion threads inside a forum; support `locked`, `sticky`, and `moved_to` flags |
+| `forum_posts` | Messages within a topic; soft deletions tracked with `deleted`, `deleted_by`, and `deleted_at` |
+| `forum_permissions` | Role‑based flags (`can_view`, `can_post`, `can_moderate`) per forum |
+| `forum_moderators` | Explicit moderator assignments for a forum |
+
+## Core Helpers
+
+* `category.php` – CRUD helpers for categories
+* `forum.php` – CRUD helpers for forums plus recursive deletion of subforums, topics, posts, and permission records
+* `topic.php` – Topic utilities including creation, moving, locking/unlocking, stickying, and audit logging
+* `post.php` – Post creation, soft deletion/restore, quoting, and list retrieval with optional deleted posts
+* `permissions.php` – Centralized permission layer combining role checks, forum‑specific assignments, and `login_check()` redirects
+
+All helpers assume a global `$conn` PDO connection and leverage `validateContentHTML()` for input sanitization.
+
+## Admin Workflow
+
+Admin pages in `admin/forum/` reuse the site's admin header/footer and are guarded by `admin_only()`:
+
+* `categories.php` – List, create, edit, and delete categories
+* `forums.php` – Manage forums and subforums, including position, description, and recursive deletion
+* `moderators.php` – Assign or revoke forum‑specific moderators
+* `global_mods.php` – Promote or demote users to the global moderator role (`users.rank = 1`)
+* `permissions.php` – Set role‑based permissions for each forum
+
+After any action the pages redirect back with a `msg` query parameter to display flash messages.
+
+## Moderator Tools
+
+Moderators and admins can perform additional actions:
+
+* **Lock/Unlock topics** – Prevent new posts when `locked = 1`
+* **Sticky/Unsticky topics** – Pin important topics to the top of listings
+* **Move topics** – Relocate threads to a different forum while leaving a locked placeholder
+* **Soft delete/restore posts** – Hide content without permanent deletion; deleted posts are excluded from standard views
+* **Quote posts** – `post_get_quote()` returns BBCode/HTML for embedding in replies
+
+Global moderators and forum‑specific moderators automatically gain `can_moderate` rights without explicit permission entries.
+
+## Testing
+
+Forum helpers ship with lightweight regression tests:
+
+```
+php tests/forum_permissions.php
+php tests/forum_delete.php
+```
+
+These scripts run against in‑memory SQLite databases to verify permission handling and recursive deletions.
+
+## Next Steps
+
+* Build user‑facing pages under `public/forum/` for browsing categories, viewing topics, and posting messages
+* Apply the planned MySpace‑style theme (`public/static/css/forum.css`)
+* Expand tests and add integration coverage once public pages exist
+

--- a/tests/forum_delete.php
+++ b/tests/forum_delete.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__.'/../core/forum/forum.php';
+
+// in-memory database for testing
+$conn = new PDO('sqlite::memory:');
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+global $conn;
+
+$conn->exec('CREATE TABLE forums (id INTEGER PRIMARY KEY, category_id INTEGER, parent_forum_id INTEGER)');
+$conn->exec('CREATE TABLE forum_topics (id INTEGER PRIMARY KEY, forum_id INTEGER)');
+$conn->exec('CREATE TABLE forum_posts (id INTEGER PRIMARY KEY, topic_id INTEGER)');
+$conn->exec('CREATE TABLE forum_moderators (forum_id INTEGER, user_id INTEGER)');
+$conn->exec('CREATE TABLE forum_permissions (forum_id INTEGER, role TEXT, can_view INTEGER, can_post INTEGER, can_moderate INTEGER)');
+
+// seed forum with a child, topics, posts, moderator and permissions
+$conn->exec("INSERT INTO forums (id, category_id, parent_forum_id) VALUES (1,1,NULL)");
+$conn->exec("INSERT INTO forums (id, category_id, parent_forum_id) VALUES (2,1,1)");
+$conn->exec("INSERT INTO forum_topics (id, forum_id) VALUES (1,1)");
+$conn->exec("INSERT INTO forum_topics (id, forum_id) VALUES (2,2)");
+$conn->exec("INSERT INTO forum_posts (id, topic_id) VALUES (1,1)");
+$conn->exec("INSERT INTO forum_posts (id, topic_id) VALUES (2,2)");
+$conn->exec("INSERT INTO forum_moderators (forum_id, user_id) VALUES (1,10)");
+$conn->exec("INSERT INTO forum_permissions (forum_id, role, can_view, can_post, can_moderate) VALUES (1,'member',1,1,0)");
+
+forum_delete_forum(1);
+
+$tables = ['forums','forum_topics','forum_posts','forum_moderators','forum_permissions'];
+$remaining = [];
+foreach ($tables as $t) {
+    $remaining[$t] = $conn->query("SELECT COUNT(*) FROM $t")->fetchColumn();
+}
+
+if (array_sum($remaining) === 0) {
+    echo "Deletion cascade OK\n";
+} else {
+    echo 'Deletion cascade failed: ' . json_encode($remaining) . "\n";
+}
+


### PR DESCRIPTION
## Summary
- Add category and forum helper functions to centralize CRUD operations
- Update forum and category admin pages to use core helpers for modularity
- Extend forum helpers with parent forum support and list retrieval

## Testing
- `php tests/forum_permissions.php`
- `php tests/forum_delete.php`


------
https://chatgpt.com/codex/tasks/task_e_689439197e28832188a62d38937025ee