### PR TITLE
Remove stray merge text from message pages

### DIFF
--- a/public/messages/inbox.php
+++ b/public/messages/inbox.php
@@ -1,9 +1,7 @@
 <?php
 require("../../core/conn.php");
 require_once("../../core/settings.php");
-97xjcb-codex/create-messages-table-and-related-features
 require_once("../../core/helper.php");
- main
 require("../../core/messages/pm.php");
 
 login_check();

--- a/public/messages/outbox.php
+++ b/public/messages/outbox.php
@@ -1,10 +1,7 @@
 <?php
 require("../../core/conn.php");
 require_once("../../core/settings.php");
- 97xjcb-codex/create-messages-table-and-related-features
 require_once("../../core/helper.php");
-=======
- main
 require("../../core/messages/pm.php");
 
 login_check();


### PR DESCRIPTION
## Summary
- Clean stray merge artefacts from `messages/inbox.php` and `messages/outbox.php`
- Ensure consecutive `require` statements for message pages

## Testing
- `php -l public/messages/inbox.php`
- `php -l public/messages/outbox.php`


------
https://chatgpt.com/codex/tasks/task_e_689686d490ac8321b9fd1fc48aaab918