### PR TITLE
Validate private message content

### DIFF
--- a/core/messages/pm.php
+++ b/core/messages/pm.php
@@ -5,7 +5,15 @@ function pm_send(int $sender_id, int $receiver_id, string $subject, string $body
 {
     global $conn;
     $cleanSubject = trim(strip_tags($subject));
+    if (mb_strlen($cleanSubject) === 0 || mb_strlen($cleanSubject) > 255) {
+        throw new InvalidArgumentException('Subject must be between 1 and 255 characters.');
+    }
+
     $cleanBody = validateContentHTML($body);
+    if (mb_strlen(trim(strip_tags($cleanBody))) === 0) {
+        throw new InvalidArgumentException('Message body cannot be empty.');
+    }
+
     $stmt = $conn->prepare('INSERT INTO messages (sender_id, receiver_id, subject, body, sent_at) VALUES (:sid, :rid, :sub, :body, CURRENT_TIMESTAMP)');
     $stmt->execute([':sid' => $sender_id, ':rid' => $receiver_id, ':sub' => $cleanSubject, ':body' => $cleanBody]);
     return (int)$conn->lastInsertId();

--- a/public/messages/compose.php
+++ b/public/messages/compose.php
@@ -17,8 +17,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $stmt->execute([':name' => $to]);
     $row = $stmt->fetch(PDO::FETCH_ASSOC);
     if ($row) {
-        pm_send($userId, (int)$row['id'], $subject, $body);
-        $message = 'Message sent!';
+        try {
+            pm_send($userId, (int)$row['id'], $subject, $body);
+            $message = 'Message sent!';
+        } catch (InvalidArgumentException $e) {
+            $message = $e->getMessage();
+        }
     } else {
         $message = 'User not found.';
     }

--- a/tests/messages_pm.php
+++ b/tests/messages_pm.php
@@ -38,6 +38,33 @@ if ($read) {
     exit(1);
 }
 
+echo "Validate inputs...\n";
+try {
+    pm_send(1, 2, '', 'Body');
+    echo "Empty subject allowed\n";
+    unlink($dbFile);
+    exit(1);
+} catch (InvalidArgumentException $e) {
+    // expected
+}
+try {
+    pm_send(1, 2, str_repeat('a', 256), 'Body');
+    echo "Long subject allowed\n";
+    unlink($dbFile);
+    exit(1);
+} catch (InvalidArgumentException $e) {
+    // expected
+}
+try {
+    pm_send(1, 2, 'Sub', '');
+    echo "Empty body allowed\n";
+    unlink($dbFile);
+    exit(1);
+} catch (InvalidArgumentException $e) {
+    // expected
+}
+echo "Validation passed\n";
+
 unlink($dbFile);
 ?>
 


### PR DESCRIPTION
## Summary
- enforce subject length (1-255 chars) and non-empty body in `pm_send`
- surface validation errors in message composer
- expand private message tests for validation failures

## Testing
- `for t in tests/*.php; do php "$t"; done`
- `php tests/messages_pm.php`

------
https://chatgpt.com/codex/tasks/task_e_689687889cd08321a2b38d8004446753