### PR TITLE
Add pagination and search to private messages

### DIFF
--- a/public/messages/inbox.php
+++ b/public/messages/inbox.php
@@ -7,6 +7,10 @@ require("../../core/messages/pm.php");
 login_check();
 
 $userId = $_SESSION['userId'];
+$limit = 20;
+$page = max(1, isset($_GET['page']) ? (int)$_GET['page'] : 1);
+$offset = ($page - 1) * $limit;
+$search = isset($_GET['search']) ? trim($_GET['search']) : null;
 
 if (isset($_GET['mark'])) {
     pm_mark_read((int)$_GET['mark'], $userId);
@@ -19,31 +23,42 @@ if (isset($_GET['del'])) {
     header('Location: inbox.php');
     exit;
 }
-
-$messages = pm_inbox($userId);
+$messages = pm_inbox($userId, $limit, $offset, $search);
 ?>
 <?php require("../header.php"); ?>
 
 <div class="simple-container">
     <h1>Inbox</h1>
     <p><a href="compose.php">Compose</a> | <a href="outbox.php">Outbox</a></p>
+    <form method="get" action="inbox.php">
+        <input type="text" name="search" value="<?= htmlspecialchars($search ?? '') ?>" placeholder="Search" />
+        <button type="submit">Go</button>
+    </form>
     <?php if (empty($messages)): ?>
         <p>No messages.</p>
     <?php else: ?>
         <ul>
             <?php foreach ($messages as $msg): ?>
                 <li>
-                    <strong><a href="?mark=<?= $msg['id'] ?>"><?= htmlspecialchars($msg['subject']) ?></a></strong>
+                    <strong><a href="?mark=<?= $msg['id'] ?>&search=<?= urlencode($search ?? '') ?>&page=<?= $page ?>"><?= htmlspecialchars($msg['subject']) ?></a></strong>
                     from <a href="../profile.php?id=<?= $msg['sender_id'] ?>"><?= htmlspecialchars($msg['sender']) ?></a>
                     on <?= htmlspecialchars($msg['sent_at']) ?>
                     <?php if (empty($msg['read_at'])): ?>
                         <em>(unread)</em>
                     <?php endif; ?>
-                    <a href="?del=<?= $msg['id'] ?>" onclick="return confirm('Delete this message?');">Delete</a>
+                    <a href="?del=<?= $msg['id'] ?>&search=<?= urlencode($search ?? '') ?>&page=<?= $page ?>" onclick="return confirm('Delete this message?');">Delete</a>
                     <div><?= nl2br(htmlspecialchars($msg['body'])) ?></div>
                 </li>
             <?php endforeach; ?>
         </ul>
+        <div class="pagination">
+            <?php if ($page > 1): ?>
+                <a href="?page=<?= $page - 1 ?>&search=<?= urlencode($search ?? '') ?>">Previous</a>
+            <?php endif; ?>
+            <?php if (count($messages) === $limit): ?>
+                <a href="?page=<?= $page + 1 ?>&search=<?= urlencode($search ?? '') ?>">Next</a>
+            <?php endif; ?>
+        </div>
     <?php endif; ?>
 </div>
 

--- a/public/messages/outbox.php
+++ b/public/messages/outbox.php
@@ -7,18 +7,26 @@ require("../../core/messages/pm.php");
 login_check();
 
 $userId = $_SESSION['userId'];
+$limit = 20;
+$page = max(1, isset($_GET['page']) ? (int)$_GET['page'] : 1);
+$offset = ($page - 1) * $limit;
+$search = isset($_GET['search']) ? trim($_GET['search']) : null;
 if (isset($_GET['del'])) {
     pm_delete((int)$_GET['del'], $userId);
     header('Location: outbox.php');
     exit;
 }
-$messages = pm_outbox($userId);
+$messages = pm_outbox($userId, $limit, $offset, $search);
 ?>
 <?php require("../header.php"); ?>
 
 <div class="simple-container">
     <h1>Outbox</h1>
     <p><a href="compose.php">Compose</a> | <a href="inbox.php">Inbox</a></p>
+    <form method="get" action="outbox.php">
+        <input type="text" name="search" value="<?= htmlspecialchars($search ?? '') ?>" placeholder="Search" />
+        <button type="submit">Go</button>
+    </form>
     <?php if (empty($messages)): ?>
         <p>No messages.</p>
     <?php else: ?>
@@ -31,11 +39,19 @@ $messages = pm_outbox($userId);
                     <?php if (empty($msg['read_at'])): ?>
                         <em>(unread)</em>
                     <?php endif; ?>
-                    <a href="?del=<?= $msg['id'] ?>" onclick="return confirm('Delete this message?');">Delete</a>
+                    <a href="?del=<?= $msg['id'] ?>&search=<?= urlencode($search ?? '') ?>&page=<?= $page ?>" onclick="return confirm('Delete this message?');">Delete</a>
                     <div><?= nl2br(htmlspecialchars($msg['body'])) ?></div>
                 </li>
             <?php endforeach; ?>
         </ul>
+        <div class="pagination">
+            <?php if ($page > 1): ?>
+                <a href="?page=<?= $page - 1 ?>&search=<?= urlencode($search ?? '') ?>">Previous</a>
+            <?php endif; ?>
+            <?php if (count($messages) === $limit): ?>
+                <a href="?page=<?= $page + 1 ?>&search=<?= urlencode($search ?? '') ?>">Next</a>
+            <?php endif; ?>
+        </div>
     <?php endif; ?>
 </div>
 

--- a/schema.sql
+++ b/schema.sql
@@ -180,7 +180,10 @@ CREATE TABLE IF NOT EXISTS `messages` (
   `read_at` datetime DEFAULT NULL,
   `sender_deleted` tinyint(1) NOT NULL DEFAULT 0,
   `receiver_deleted` tinyint(1) NOT NULL DEFAULT 0,
-  PRIMARY KEY  (`id`)
+  PRIMARY KEY  (`id`),
+  KEY `idx_messages_receiver` (`receiver_id`,`receiver_deleted`,`sent_at`),
+  KEY `idx_messages_sender` (`sender_id`,`sender_deleted`,`sent_at`),
+  FULLTEXT KEY `idx_messages_search` (`subject`,`body`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- --------------------------------------------------------


### PR DESCRIPTION
## Summary
- Support limit/offset pagination and optional keyword search in `pm_inbox` and `pm_outbox`
- Add pagination controls and search forms to inbox and outbox views
- Add database indexes for message queries and tests for paginated and filtered results

## Testing
- `php tests/messages_pm.php`
- `php tests/forum_mod_dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68968a9d06088321a170da178b35b02e