### PR TITLE
Add message threading to private messages

### DIFF
--- a/anyspace.sql
+++ b/anyspace.sql
@@ -113,6 +113,7 @@ CREATE TABLE IF NOT EXISTS `layouts` (
 
 CREATE TABLE IF NOT EXISTS `messages` (
   `id` int(11) NOT NULL auto_increment,
+  `thread_id` int(11) NOT NULL,
   `toid` int(11) NOT NULL,
   `author` int(11) NOT NULL,
   `msg` text NOT NULL,

--- a/public/messages/compose.php
+++ b/public/messages/compose.php
@@ -7,18 +7,35 @@ login_check();
 
 $userId = $_SESSION['userId'];
 $message = '';
+$toPrefill = '';
+$subjectPrefill = '';
+$parentId = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['reply_to'])) {
+    $parentId = (int)$_GET['reply_to'];
+    $stmt = $conn->prepare('SELECT sender_id, receiver_id, subject FROM messages WHERE id = :id');
+    $stmt->execute([':id' => $parentId]);
+    if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        $otherId = ((int)$row['sender_id'] === $userId) ? (int)$row['receiver_id'] : (int)$row['sender_id'];
+        $stmt2 = $conn->prepare('SELECT username FROM users WHERE id = :id');
+        $stmt2->execute([':id' => $otherId]);
+        $toPrefill = (string)$stmt2->fetchColumn();
+        $subjectPrefill = 'Re: ' . $row['subject'];
+    }
+}
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $to = trim($_POST['to'] ?? '');
     $subject = trim($_POST['subject'] ?? '');
     $body = trim($_POST['body'] ?? '');
+    $parentId = isset($_POST['parent_id']) ? (int)$_POST['parent_id'] : null;
 
     $stmt = $conn->prepare('SELECT id FROM users WHERE username = :name');
     $stmt->execute([':name' => $to]);
     $row = $stmt->fetch(PDO::FETCH_ASSOC);
     if ($row) {
         try {
-            pm_send($userId, (int)$row['id'], $subject, $body);
+            pm_send($userId, (int)$row['id'], $subject, $body, $parentId);
             $message = 'Message sent!';
         } catch (InvalidArgumentException $e) {
             $message = $e->getMessage();
@@ -38,8 +55,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <?php endif; ?>
     <form method="post">
     <?= csrf_token_input(); ?>
-        <p><label>To: <input type="text" name="to" required></label></p>
-        <p><label>Subject: <input type="text" name="subject" required></label></p>
+        <input type="hidden" name="parent_id" value="<?= htmlspecialchars($parentId ?? '') ?>">
+        <p><label>To: <input type="text" name="to" value="<?= htmlspecialchars($toPrefill) ?>" required></label></p>
+        <p><label>Subject: <input type="text" name="subject" value="<?= htmlspecialchars($subjectPrefill) ?>" required></label></p>
         <p><label>Message:<br>
             <textarea name="body" rows="8" cols="40" required></textarea></label></p>
         <p><button type="submit">Send</button></p>

--- a/public/messages/inbox.php
+++ b/public/messages/inbox.php
@@ -23,7 +23,7 @@ if (isset($_GET['del'])) {
     header('Location: inbox.php');
     exit;
 }
-$messages = pm_inbox($userId, $limit, $offset, $search);
+$threads = pm_inbox($userId, $limit, $offset, $search);
 ?>
 <?php require("../header.php"); ?>
 
@@ -34,20 +34,29 @@ $messages = pm_inbox($userId, $limit, $offset, $search);
         <input type="text" name="search" value="<?= htmlspecialchars($search ?? '') ?>" placeholder="Search" />
         <button type="submit">Go</button>
     </form>
-    <?php if (empty($messages)): ?>
+    <?php if (empty($threads)): ?>
         <p>No messages.</p>
     <?php else: ?>
         <ul>
-            <?php foreach ($messages as $msg): ?>
+            <?php foreach ($threads as $thread): ?>
+                <?php $msgs = $thread['messages']; $last = end($msgs); $otherName = ($last['sender_id'] == $userId) ? $last['receiver'] : $last['sender']; $otherId = ($last['sender_id'] == $userId) ? $last['receiver_id'] : $last['sender_id']; ?>
                 <li>
-                    <strong><a href="?mark=<?= $msg['id'] ?>&search=<?= urlencode($search ?? '') ?>&page=<?= $page ?>"><?= htmlspecialchars($msg['subject']) ?></a></strong>
-                    from <a href="../profile.php?id=<?= $msg['sender_id'] ?>"><?= htmlspecialchars($msg['sender']) ?></a>
-                    on <?= htmlspecialchars($msg['sent_at']) ?>
-                    <?php if (empty($msg['read_at'])): ?>
-                        <em>(unread)</em>
-                    <?php endif; ?>
-                    <a href="?del=<?= $msg['id'] ?>&search=<?= urlencode($search ?? '') ?>&page=<?= $page ?>" onclick="return confirm('Delete this message?');">Delete</a>
-                    <div><?= nl2br(htmlspecialchars($msg['body'])) ?></div>
+                    <strong>Conversation with <a href="../profile.php?id=<?= $otherId ?>"><?= htmlspecialchars($otherName) ?></a></strong>
+                    <ul>
+                        <?php foreach ($msgs as $msg): ?>
+                            <li>
+                                <strong><a href="?mark=<?= $msg['id'] ?>&search=<?= urlencode($search ?? '') ?>&page=<?= $page ?>"><?= htmlspecialchars($msg['subject']) ?></a></strong>
+                                from <a href="../profile.php?id=<?= $msg['sender_id'] ?>"><?= htmlspecialchars($msg['sender']) ?></a>
+                                on <?= htmlspecialchars($msg['sent_at']) ?>
+                                <?php if (empty($msg['read_at']) && $msg['receiver_id'] == $userId): ?>
+                                    <em>(unread)</em>
+                                <?php endif; ?>
+                                <a href="?del=<?= $msg['id'] ?>&search=<?= urlencode($search ?? '') ?>&page=<?= $page ?>" onclick="return confirm('Delete this message?');">Delete</a>
+                                <div><?= nl2br(htmlspecialchars($msg['body'])) ?></div>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                    <p><a href="compose.php?reply_to=<?= $last['id'] ?>">Reply</a></p>
                 </li>
             <?php endforeach; ?>
         </ul>
@@ -55,7 +64,7 @@ $messages = pm_inbox($userId, $limit, $offset, $search);
             <?php if ($page > 1): ?>
                 <a href="?page=<?= $page - 1 ?>&search=<?= urlencode($search ?? '') ?>">Previous</a>
             <?php endif; ?>
-            <?php if (count($messages) === $limit): ?>
+            <?php if (count($threads) === $limit): ?>
                 <a href="?page=<?= $page + 1 ?>&search=<?= urlencode($search ?? '') ?>">Next</a>
             <?php endif; ?>
         </div>

--- a/schema.sql
+++ b/schema.sql
@@ -172,6 +172,7 @@ CREATE TABLE IF NOT EXISTS `layouts` (
 
 CREATE TABLE IF NOT EXISTS `messages` (
   `id` int(11) NOT NULL auto_increment,
+  `thread_id` int(11) NOT NULL,
   `sender_id` int(11) NOT NULL,
   `receiver_id` int(11) NOT NULL,
   `subject` varchar(255) NOT NULL,
@@ -181,6 +182,7 @@ CREATE TABLE IF NOT EXISTS `messages` (
   `sender_deleted` tinyint(1) NOT NULL DEFAULT 0,
   `receiver_deleted` tinyint(1) NOT NULL DEFAULT 0,
   PRIMARY KEY  (`id`),
+  KEY `idx_messages_thread` (`thread_id`),
   KEY `idx_messages_receiver` (`receiver_id`,`receiver_deleted`,`sent_at`),
   KEY `idx_messages_sender` (`sender_id`,`sender_deleted`,`sent_at`),
   FULLTEXT KEY `idx_messages_search` (`subject`,`body`)


### PR DESCRIPTION
## Summary
- Track message threads with new `thread_id` column
- Group inbox/outbox results by thread and allow replying within threads
- Test thread creation, retrieval, and conversation pagination

## Testing
- `php tests/messages_pm.php`


------
https://chatgpt.com/codex/tasks/task_e_68968c8dd5bc8321a309c78898748e45