### PR TITLE
Remove stray merge text from PHP pages

### DIFF
--- a/admin/forum/forums.php
+++ b/admin/forum/forums.php
@@ -5,11 +5,6 @@ require("../../core/config.php");
 require_once("../../core/forum/category.php");
 require_once("../../core/forum/forum.php");
 admin_only();
-=======
- su0k9s-codex/explain-codebase-structure-and-key-concepts
-require_once("../../core/forum/category.php");
-require_once("../../core/forum/forum.php");
-admin_only();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // Add forum

--- a/public/messages/inbox.php
+++ b/public/messages/inbox.php
@@ -1,9 +1,7 @@
 <?php
 require("../../core/conn.php");
 require_once("../../core/settings.php");
-97xjcb-codex/create-messages-table-and-related-features
 require_once("../../core/helper.php");
- main
 require("../../core/messages/pm.php");
 
 login_check();

--- a/public/messages/outbox.php
+++ b/public/messages/outbox.php
@@ -1,10 +1,7 @@
 <?php
 require("../../core/conn.php");
 require_once("../../core/settings.php");
- 97xjcb-codex/create-messages-table-and-related-features
 require_once("../../core/helper.php");
-=======
- main
 require("../../core/messages/pm.php");
 
 login_check();


### PR DESCRIPTION
## Summary
- Clean stray merge artefacts from `messages/inbox.php` and `messages/outbox.php`
- Strip leftover branch text from `admin/forum/forums.php`
- Ensure consecutive `require` statements for message and forum pages

## Testing
- `php -l admin/forum/forums.php`
- `php -l public/messages/inbox.php`
- `php -l public/messages/outbox.php`
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_689686d490ac8321b9fd1fc48aaab918