### PR TITLE
Filter forum search by view permissions

### DIFF
--- a/public/forum/search.php
+++ b/public/forum/search.php
@@ -2,13 +2,14 @@
 require __DIR__ . "/../../core/conn.php";
 require_once __DIR__ . "/../../core/settings.php";
 require_once __DIR__ . "/../../core/forum/forum.php";
+require_once __DIR__ . "/../../core/forum/permissions.php";
 
 $pageCSS = "../static/css/forum.css";
 
 $query = isset($_GET['q']) ? trim($_GET['q']) : '';
 $results = [];
 if ($query !== '') {
-    $results = searchTopics($query);
+    $results = searchTopics($query, forum_user_role());
 }
 ?>
 <?php require __DIR__ . "/../header.php"; ?>

--- a/tests/forum_search.php
+++ b/tests/forum_search.php
@@ -8,12 +8,17 @@ putenv('DB_DSN=' . $dsn);
 
 $conn = new PDO($dsn);
 $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-$conn->exec('CREATE TABLE forum_topics (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT)');
+$conn->exec('CREATE TABLE forums (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+$conn->exec('CREATE TABLE forum_topics (id INTEGER PRIMARY KEY AUTOINCREMENT, forum_id INTEGER, title TEXT)');
 $conn->exec('CREATE TABLE forum_posts (id INTEGER PRIMARY KEY AUTOINCREMENT, topic_id INTEGER, body TEXT)');
-$conn->exec("INSERT INTO forum_topics (title) VALUES ('Hello World')");
+$conn->exec('CREATE TABLE forum_permissions (forum_id INTEGER, role TEXT, can_view INTEGER, can_post INTEGER, can_moderate INTEGER)');
+$conn->exec("INSERT INTO forums (id, name) VALUES (1, 'Public'), (2, 'Private')");
+$conn->exec("INSERT INTO forum_topics (forum_id, title) VALUES (1, 'Hello World')");
 $conn->exec("INSERT INTO forum_posts (topic_id, body) VALUES (1, 'First post body')");
-$conn->exec("INSERT INTO forum_topics (title) VALUES ('Another Topic')");
+$conn->exec("INSERT INTO forum_topics (forum_id, title) VALUES (2, 'Another Topic')");
 $conn->exec("INSERT INTO forum_posts (topic_id, body) VALUES (2, 'Something else')");
+$conn->exec("INSERT INTO forum_permissions (forum_id, role, can_view, can_post, can_moderate) VALUES (1, 'guest', 1, 0, 0)");
+$conn->exec("INSERT INTO forum_permissions (forum_id, role, can_view, can_post, can_moderate) VALUES (2, 'guest', 0, 0, 0)");
 
 $siteName = 'AnySpace';
 $domainName = 'example.com';
@@ -26,7 +31,12 @@ ob_start();
 require __DIR__ . '/../public/forum/search.php';
 $output = ob_get_clean();
 
-if (strpos($output, 'Hello World') !== false && strpos($output, 'Another Topic') === false) {
+$_GET['q'] = 'Another';
+ob_start();
+require __DIR__ . '/../public/forum/search.php';
+$output2 = ob_get_clean();
+
+if (strpos($output, 'Hello World') !== false && strpos($output2, 'Another Topic') === false) {
     echo "Forum search works\n";
 } else {
     echo "Forum search failed\n";


### PR DESCRIPTION
## Summary
- Respect forum_permissions in forum topic searches
- Pass current user role to searchTopics and filter results accordingly
- Add test coverage ensuring restricted topics are excluded

## Testing
- `php tests/forum_search.php`
- `for file in tests/*.php; do php "$file"; done`

------
https://chatgpt.com/codex/tasks/task_e_689bf7bdada88321990e1937f2256ac0