### PR TITLE
docs: document forum reactions and polls

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ system.
   - [x] Content Filtering
   - [x] Audit Logging
   - [x] Statistics Caching
+  - [x] Reactions & Polls
 - [x] Friend System
 - [x] Group System
 - [x] Layout sharing feature
@@ -72,6 +73,8 @@ system.
 - [x] User Search
 - [x] User Profiles
 - [x] Custom HTML/CSS Profile Layouts
+
+For detailed forum documentation, see [docs/forum/README.md](docs/forum/README.md).
 
 ## Screenshot
 

--- a/docs/forum/README.md
+++ b/docs/forum/README.md
@@ -24,6 +24,8 @@ This module provides a complete, production-ready discussion board with hierarch
 - **Notifications**: Real-time notifications for replies and mentions
 - **Subscriptions**: Topic subscription system
 - **File Attachments**: Support for file uploads on posts
+- **Post Reactions**: Like/dislike system for posts
+- **Topic Polls**: Built-in polling for topics
 - **Rich Content**: HTML content support with safe sanitization
 
 ### ✅ Moderation Tools
@@ -103,6 +105,8 @@ The schema extends `schema.sql` with production-ready tables:
 * **Notifications** – Alerts for replies and @mentions
 * **Subscriptions** – Topic following with notifications
 * **File Uploads** – Attachment support for posts
+* **Reactions** – Like/dislike on posts
+* **Polls** – Built-in topic polls
 * **Responsive UI** – Mobile-friendly interface
 
 ### Moderation Features


### PR DESCRIPTION
## Summary
- document new forum features: post reactions and topic polls
- link forum module docs from main README

## Testing
- `for t in tests/*.php; do php "$t"; done`

------
https://chatgpt.com/codex/tasks/task_e_689bfb83670c83219e9acbea0da624ba