### PR TITLE
feat: introduce theme variables and dark mode

### DIFF
--- a/public/static/css/base.css
+++ b/public/static/css/base.css
@@ -31,9 +31,16 @@ html {
   --light-green: #E6F8DD;
   --medium-green: #A0C99C;
   --dark-green: #059669;
+  --background-color: #e5e5e5;
+  --text-color: #000000;
+  --accent-color: var(--logo-blue);
+  accent-color: var(--accent-color);
+}
 
-  accent-color: #1D4ED8;
-  accent-color: var(--logo-blue);
+body.dark-mode {
+  --background-color: #111111;
+  --text-color: #f5f5f5;
+  --accent-color: #93c5fd;
 }
 
 *{
@@ -50,18 +57,16 @@ html, body{
 
 body {
   font-family: verdana, arial, sans-serif, helvetica;
-  background-color: #ffffff;
-  color: #000000;
+  background-color: var(--background-color);
+  color: var(--text-color);
   font-size: 16px;
   margin: 0;
 }
 
-/**
 a {
-  font-weight: bold;
+  color: var(--accent-color);
   text-decoration: none;
 }
-**/
 
 
 a:hover {
@@ -84,16 +89,6 @@ button:focus {
   outline: 3px solid var(--dark-orange);
   outline-offset: 2px;
 }
-
-body.dark-mode {
-  background-color: #111111;
-  color: #f5f5f5;
-}
-
-body.dark-mode a {
-  color: #93c5fd;
-}
-
 body.large-text {
   font-size: 20px;
 }

--- a/public/static/css/forum.css
+++ b/public/static/css/forum.css
@@ -4,8 +4,8 @@
 body {
     font-family: Verdana, Arial, sans-serif;
     font-size: 12pt;
-    background-color: var(--light-gray);
-    color: #000000;
+    background-color: var(--background-color);
+    color: var(--text-color);
     background-image: repeating-linear-gradient(
         45deg,
         var(--lighter-blue) 0 20px,
@@ -13,9 +13,13 @@ body {
     );
 }
 
+a {
+    color: var(--accent-color);
+}
+
 .forum-header,
 .forum-post {
-    background-image: linear-gradient(to bottom, var(--logo-blue), var(--light-orange));
+    background-image: linear-gradient(to bottom, var(--accent-color), var(--light-orange));
     color: #fff;
 }
 
@@ -25,7 +29,7 @@ body {
 }
 
 .forum-category-section h2 {
-    background: linear-gradient(to right, var(--logo-blue), var(--light-orange));
+    background: linear-gradient(to right, var(--accent-color), var(--light-orange));
     color: white;
     padding: 10px;
     margin: 0 0 10px 0;
@@ -52,11 +56,11 @@ body {
 
 .forum-item h3 {
     margin: 0 0 5px 0;
-    color: var(--logo-blue);
+    color: var(--accent-color);
 }
 
 .forum-item h3 a {
-    color: var(--logo-blue);
+    color: var(--accent-color);
     text-decoration: none;
     font-weight: bold;
 }
@@ -96,7 +100,7 @@ body {
 
 .forum-search button {
     padding: 8px 15px;
-    background: linear-gradient(to bottom, var(--logo-blue), var(--darker-blue));
+    background: linear-gradient(to bottom, var(--accent-color), var(--darker-blue));
     color: white;
     border: none;
     border-radius: 3px;
@@ -128,7 +132,7 @@ body {
 
 .forum-table th,
 .post-table th {
-    background: linear-gradient(to bottom, var(--logo-blue), var(--darker-blue));
+    background: linear-gradient(to bottom, var(--accent-color), var(--darker-blue));
     color: white;
     font-weight: bold;
 }
@@ -210,8 +214,9 @@ button:focus {
 }
 
 body.dark-mode {
-    background-color: #1a1a1a;
-    color: #e5e5e5;
+    --background-color: #1a1a1a;
+    --text-color: #e5e5e5;
+    --accent-color: #93c5fd;
     background-image: none;
 }
 
@@ -275,7 +280,7 @@ body.large-text {
 }
 
 .reply-submit {
-    background: linear-gradient(to bottom, var(--logo-blue), var(--darker-blue));
+    background: linear-gradient(to bottom, var(--accent-color), var(--darker-blue));
     color: white;
     border: 1px solid var(--dark-gray);
     padding: 8px 16px;
@@ -285,7 +290,7 @@ body.large-text {
 }
 
 .reply-submit:hover {
-    background: linear-gradient(to bottom, var(--darker-blue), var(--logo-blue));
+    background: linear-gradient(to bottom, var(--darker-blue), var(--accent-color));
 }
 
 .reply-clear {

--- a/public/static/css/mod.css
+++ b/public/static/css/mod.css
@@ -10,7 +10,8 @@
     margin-bottom: 1em;
 }
 .mod-dashboard .stat {
-    background: #f0f0f0;
+    background: var(--background-color);
+    color: var(--text-color);
     padding: 0.5em 1em;
     border-radius: 4px;
 }
@@ -20,7 +21,7 @@
 }
 .mod-dashboard th,
 .mod-dashboard td {
-    border: 1px solid #ccc;
+    border: 1px solid var(--gray);
     padding: 0.5em;
     text-align: left;
 }

--- a/public/static/css/my.css
+++ b/public/static/css/my.css
@@ -1,4 +1,3 @@
-/*
 :root{
     --light-gray: #f2f0f0;
     --gray: #e3e3e3;
@@ -18,10 +17,17 @@
     --light-green: #E6F8DD;
     --medium-green: #A0C99C;
     --dark-green: #059669;
-  
-    accent-color: #1D4ED8;
-    accent-color: var(--logo-blue);
+    --background-color: #e5e5e5;
+    --text-color: #000000;
+    --accent-color: var(--logo-blue);
+    accent-color: var(--accent-color);
   }
+
+body.dark-mode {
+    --background-color: #1a1a1a;
+    --text-color: #f5f5f5;
+    --accent-color: #93c5fd;
+}
   
   *{
     box-sizing: border-box;
@@ -35,8 +41,8 @@
     padding: 0;
   }
   body{
-    background-color: #e3e3e3;
-    background-color: var(--gray);
+    background-color: var(--background-color);
+    color: var(--text-color);
     font-family: verdana, arial, sans-serif, helvetica;
   }
   .container{
@@ -52,14 +58,12 @@
   .soon{
     opacity: 0.7;
   }
-  */
   details summary{
     cursor: pointer;
     user-select: none;
   }
   a{
-    color: #1E40AF;
-    color: var(--darker-blue);
+    color: var(--accent-color);
     text-decoration: none;
   }
   a:hover,
@@ -109,7 +113,7 @@
     background: var(--even-lighter-orange);
   }
   nav .top {
-    background: var(--logo-blue);
+    background: var(--accent-color);
     padding: 15px 10px 14px 10px;
     display: flex;
     align-items: flex-start;
@@ -612,7 +616,7 @@
     width: 100%;
   }
   .info-box{
-    border: 1px solid #1E40AF;
+    border: 1px solid var(--darker-blue);
     border: 1px solid var(--darker-blue);
     background: #BFDBFE;
     background: var(--even-lighter-blue);
@@ -628,7 +632,7 @@
     margin: 0;
   }
   .info-box h3{
-    color: #1E40AF;
+    color: var(--darker-blue);
     color: var(--darker-blue);
     margin: 0;
     margin-bottom: 5px;
@@ -741,8 +745,8 @@
   .details-table td:first-child{
     background: #BFDBFE;
     background: var(--even-lighter-blue);
-    color: #1D4ED8;
-    color: var(--logo-blue);
+    color: var(--accent-color);
+    color: var(--accent-color);
     font-weight: bold;
     width: 33%;
   }
@@ -811,7 +815,7 @@
     cursor: pointer;
     user-select: text;
     text-decoration: none;
-    color: #1E40AF;
+    color: var(--darker-blue);
     color: var(--darker-blue);
   }
   .logout-btn,
@@ -1183,7 +1187,7 @@
     margin: 15px 0;
   }
   .statistics .heading{
-    background: #1E40AF;
+    background: var(--darker-blue);
     background: var(--darker-blue);
     color: white;
     padding: 2px 7px;
@@ -1556,7 +1560,7 @@
   .about-banner,
   .help-banner,
   .press-banner{
-    background: #1D4ED8;
+    background: var(--accent-color);
     width: 100%;
     padding: 15px;
     margin: 10px 0;
@@ -1632,8 +1636,8 @@
     padding-right: 20px;
   }
   .sticker-banner{
-    background: #1D4ED8;
-    background: var(--logo-blue);
+    background: var(--accent-color);
+    background: var(--accent-color);
     padding: 2px 0 0 5px;
     cursor: pointer;
     margin: 0 0 10px 0;
@@ -1744,8 +1748,8 @@
     min-height: 70px;
     width: 300px;
     max-width: 100%;
-    background: #1D4ED8;
-    background: var(--logo-blue);
+    background: var(--accent-color);
+    background: var(--accent-color);
     color: white;
     font-weight: bold;
     font-size: 2em;
@@ -1772,7 +1776,7 @@
     margin: 10px 0 6px 0;
   }
   ul.group-actions li{
-    color: #1E40AF;
+    color: var(--darker-blue);
     color: var(--darker-blue);
     background: #BFDBFE;
     background: var(--even-lighter-blue);
@@ -2079,8 +2083,8 @@
     margin-right: auto;
   }
   #captcha .heading{
-    background: #1D4ED8;
-    background: var(--logo-blue);
+    background: var(--accent-color);
+    background: var(--accent-color);
     padding: 2px 7px;
     color: white;
     width: 100%;

--- a/public/static/css/style.css
+++ b/public/static/css/style.css
@@ -17,8 +17,16 @@
     --light-green: #E6F8DD;
     --medium-green: #A0C99C;
     --dark-green: #059669;
-    accent-color: #1D4ED8;
-    accent-color: var(--logo-blue);
+    --background-color: #e5e5e5;
+    --text-color: #000000;
+    --accent-color: var(--logo-blue);
+    accent-color: var(--accent-color);
+}
+
+body.dark-mode {
+    --background-color: #1a1a1a;
+    --text-color: #f5f5f5;
+    --accent-color: #93c5fd;
 }
 
 * {
@@ -36,7 +44,8 @@ html, body {
 
 body {
     font-family: verdana, arial, sans-serif, helvetica;
-    background-color: #e5e5e5;
+    background-color: var(--background-color);
+    color: var(--text-color);
     /*font-size: 10pt;*/
     margin: 0;
 }
@@ -47,8 +56,7 @@ details summary {
 }
 
 a {
-    color: #1E40AF;
-    color: var(--darker-blue);
+    color: var(--accent-color);
     text-decoration: none;
 }
 
@@ -103,7 +111,7 @@ nav {
 }
 
 nav .top {
-    background: var(--logo-blue);
+    background: var(--accent-color);
     padding: 15px 10px 14px 10px;
     display: flex;
     align-items: flex-start;
@@ -854,7 +862,7 @@ table.details-table {
     background: #BFDBFE;
     background: var(--even-lighter-blue);
     color: #1D4ED8;
-    color: var(--logo-blue);
+    color: var(--accent-color);
     font-weight: bold;
     width: 33%;
 }
@@ -1923,7 +1931,7 @@ div.wysiwyg {
 
 .sticker-banner {
     background: #1D4ED8;
-    background: var(--logo-blue);
+    background: var(--accent-color);
     padding: 2px 0 0 5px;
     cursor: pointer;
     margin: 0 0 10px 0;
@@ -2066,7 +2074,7 @@ div.wysiwyg {
     width: 300px;
     max-width: 100%;
     background: #1D4ED8;
-    background: var(--logo-blue);
+    background: var(--accent-color);
     color: white;
     font-weight: bold;
     font-size: 2em;
@@ -2478,7 +2486,7 @@ blink {
 
 #captcha .heading {
     background: #1D4ED8;
-    background: var(--logo-blue);
+    background: var(--accent-color);
     padding: 2px 7px;
     color: white;
     width: 100%;


### PR DESCRIPTION
## Summary
- use CSS custom properties for background, text, and accent colors
- add dark-mode variable overrides in main styles
- update remaining stylesheets to consume shared theme variables

## Testing
- `for t in tests/*.php; do php "$t" > /dev/null; done && echo "tests completed"`

------
https://chatgpt.com/codex/tasks/task_e_689c05c8b4f08321919013e203132d91