### PR TITLE
Split dark mode and large text preferences

### DIFF
--- a/public/header.php
+++ b/public/header.php
@@ -64,6 +64,17 @@ header("Content-Security-Policy: default-src 'self'; img-src 'self' data:; style
 </head>
 
 <body>
+    <script>
+        (function(){
+            const body=document.body;
+            if(localStorage.getItem('darkMode')==='true'){
+                body.classList.add('dark-mode');
+            }
+            if(localStorage.getItem('largeText')==='true'){
+                body.classList.add('large-text');
+            }
+        })();
+    </script>
     <div class="master-container">
         <?php require_once __DIR__ . "/../core/components/navbar.php"; ?>
         <main>

--- a/public/settings.php
+++ b/public/settings.php
@@ -123,7 +123,9 @@ if (isset($_POST['password-old']) && isset($_POST['password-new']) && isset($_PO
         <h4>Display Options</h4>
       </div>
       <div class="inner">
-        <label><input type="checkbox" id="accessibilityToggle" aria-label="Enable dark mode and larger text"> Dark mode / larger text</label>
+        <label><input type="checkbox" id="darkModeToggle" aria-label="Enable dark mode"> Dark mode</label>
+        <br>
+        <label><input type="checkbox" id="largeTextToggle" aria-label="Enable larger text"> Larger text</label>
       </div>
     </div>
 
@@ -155,17 +157,26 @@ if (isset($_POST['password-old']) && isset($_POST['password-new']) && isset($_PO
     <button type="submit" name="submit">Save All</button>
   </form>
   <script>
-    const toggle=document.getElementById('accessibilityToggle');
+    const darkToggle=document.getElementById('darkModeToggle');
+    const textToggle=document.getElementById('largeTextToggle');
     const body=document.body;
-    const stored=localStorage.getItem('accessibilityMode')==='true';
-    if(stored){
-      body.classList.add('dark-mode','large-text');
-      toggle.checked=true;
+    const darkStored=localStorage.getItem('darkMode')==='true';
+    const textStored=localStorage.getItem('largeText')==='true';
+    if(darkStored){
+      body.classList.add('dark-mode');
+      darkToggle.checked=true;
     }
-    toggle.addEventListener('change',()=>{
-      body.classList.toggle('dark-mode',toggle.checked);
-      body.classList.toggle('large-text',toggle.checked);
-      localStorage.setItem('accessibilityMode',toggle.checked);
+    if(textStored){
+      body.classList.add('large-text');
+      textToggle.checked=true;
+    }
+    darkToggle.addEventListener('change',()=>{
+      body.classList.toggle('dark-mode',darkToggle.checked);
+      localStorage.setItem('darkMode',darkToggle.checked);
+    });
+    textToggle.addEventListener('change',()=>{
+      body.classList.toggle('large-text',textToggle.checked);
+      localStorage.setItem('largeText',textToggle.checked);
     });
   </script>
   <br>


### PR DESCRIPTION
## Summary
- Replace combined accessibility checkbox with individual **Dark mode** and **Larger text** toggles
- Store and apply dark mode and large text preferences independently across the site

## Testing
- `php -l public/settings.php`
- `php -l public/header.php`
- `{ for f in tests/*.php; do echo "Running $f"; php "$f"; done; } | nl -ba`


------
https://chatgpt.com/codex/tasks/task_e_689c0843b16083218a7941e22dfa08a2