### PR TITLE
feat: load user theme preferences

### DIFF
--- a/public/header.php
+++ b/public/header.php
@@ -65,12 +65,22 @@ header("Content-Security-Policy: default-src 'self'; img-src 'self' data:; style
 
 <body>
     <script>
-        (function(){
-            const body=document.body;
-            if(localStorage.getItem('darkMode')==='true'){
+        (function () {
+            const body = document.body;
+
+            let darkMode = localStorage.getItem('darkMode');
+            if (darkMode === null) {
+                darkMode = <?= isset($_COOKIE['darkMode']) ? json_encode($_COOKIE['darkMode']) : 'null'; ?>;
+            }
+            if (darkMode === 'true' || darkMode === true) {
                 body.classList.add('dark-mode');
             }
-            if(localStorage.getItem('largeText')==='true'){
+
+            let largeText = localStorage.getItem('largeText');
+            if (largeText === null) {
+                largeText = <?= isset($_COOKIE['largeText']) ? json_encode($_COOKIE['largeText']) : 'null'; ?>;
+            }
+            if (largeText === 'true' || largeText === true) {
                 body.classList.add('large-text');
             }
         })();


### PR DESCRIPTION
## Summary
- initialize user theme and font size preferences from localStorage or cookies
- apply `dark-mode` and `large-text` classes before rendering

## Testing
- `php -l public/header.php`
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_689c0b091100832182891a55ef092829