### PR TITLE
Allow users to customize interface colors

### DIFF
--- a/core/forum.php
+++ b/core/forum.php
@@ -4,23 +4,24 @@ require_once(__DIR__.'/forum/permissions.php');
 
 function forum_get_user_settings($user_id) {
     global $conn;
-    $stmt = $conn->prepare('SELECT background_image_url, background_color, text_color FROM forum_user_settings WHERE user_id = :uid');
+    $stmt = $conn->prepare('SELECT background_image_url, background_color, text_color, accent_color FROM forum_user_settings WHERE user_id = :uid');
     $stmt->execute([':uid' => $user_id]);
     $settings = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$settings) {
-        $settings = ['background_image_url' => '', 'background_color' => '', 'text_color' => ''];
+        $settings = ['background_image_url' => '', 'background_color' => '', 'text_color' => '', 'accent_color' => ''];
     }
     return $settings;
 }
 
-function forum_save_user_settings($user_id, $bg_url, $bg_color, $text_color) {
+function forum_save_user_settings($user_id, $bg_url, $bg_color, $text_color, $accent_color = null) {
     global $conn;
-    $stmt = $conn->prepare('INSERT INTO forum_user_settings (user_id, background_image_url, background_color, text_color) VALUES (:uid, :bg_url, :bg_color, :text_color) ON DUPLICATE KEY UPDATE background_image_url = VALUES(background_image_url), background_color = VALUES(background_color), text_color = VALUES(text_color)');
+    $stmt = $conn->prepare('INSERT INTO forum_user_settings (user_id, background_image_url, background_color, text_color, accent_color) VALUES (:uid, :bg_url, :bg_color, :text_color, :accent_color) ON DUPLICATE KEY UPDATE background_image_url = VALUES(background_image_url), background_color = VALUES(background_color), text_color = VALUES(text_color), accent_color = VALUES(accent_color)');
     $stmt->execute([
         ':uid' => $user_id,
         ':bg_url' => $bg_url,
         ':bg_color' => $bg_color,
-        ':text_color' => $text_color
+        ':text_color' => $text_color,
+        ':accent_color' => $accent_color
     ]);
 }
 ?>

--- a/core/site/user.php
+++ b/core/site/user.php
@@ -79,6 +79,37 @@ function fetchFontSize($id) {
     return $result[0]['font_size'];
 }
 
+function fetchUserColors($id) {
+    global $conn;
+    $stmt = $conn->prepare("SELECT accent_color, background_color, text_color FROM forum_user_settings WHERE user_id = :id");
+    $stmt->execute(array(':id' => $id));
+    $result = $stmt->fetch(PDO::FETCH_ASSOC);
+    $defaults = array(
+        'accent_color' => '#003399',
+        'background_color' => '#e5e5e5',
+        'text_color' => '#000000'
+    );
+    if (!$result) {
+        return $defaults;
+    }
+    return array(
+        'accent_color' => $result['accent_color'] ?: $defaults['accent_color'],
+        'background_color' => $result['background_color'] ?: $defaults['background_color'],
+        'text_color' => $result['text_color'] ?: $defaults['text_color']
+    );
+}
+
+function saveUserColors($id, $accent, $background, $text) {
+    global $conn;
+    $stmt = $conn->prepare("INSERT INTO forum_user_settings (user_id, accent_color, background_color, text_color) VALUES (:id, :accent, :background, :text) ON DUPLICATE KEY UPDATE accent_color = VALUES(accent_color), background_color = VALUES(background_color), text_color = VALUES(text_color)");
+    $stmt->execute(array(
+        ':id' => $id,
+        ':accent' => $accent,
+        ':background' => $background,
+        ':text' => $text
+    ));
+}
+
 function fetchUserStatus($id) {
     global $conn;
     try {

--- a/public/header.php
+++ b/public/header.php
@@ -4,6 +4,15 @@ if (session_status() == PHP_SESSION_NONE) {
     session_start();
 }
 require_once __DIR__ . '/../core/helper.php';
+require_once __DIR__ . '/../core/conn.php';
+require_once __DIR__ . '/../core/site/user.php';
+
+$defaultColors = array('accent_color' => '#003399', 'background_color' => '#e5e5e5', 'text_color' => '#000000');
+if (isset($_SESSION['userId'])) {
+    $userColors = fetchUserColors($_SESSION['userId']);
+    $defaultColors = array_merge($defaultColors, $userColors);
+}
+$bodyStyle = '--accent-color: ' . $defaultColors['accent_color'] . '; --background-color: ' . $defaultColors['background_color'] . '; --text-color: ' . $defaultColors['text_color'] . ';';
 ?>
 <!DOCTYPE html>
 <html>
@@ -67,7 +76,7 @@ require_once __DIR__ . '/../core/helper.php';
     </style>
 </head>
 
-<body class="<?= get_theme_classes(); ?>">
+<body class="<?= get_theme_classes(); ?>" style="<?= htmlspecialchars($bodyStyle, ENT_QUOTES) ?>">
     <div class="master-container">
         <?php require_once __DIR__ . "/../core/components/navbar.php"; ?>
         <main>

--- a/public/settings.php
+++ b/public/settings.php
@@ -40,10 +40,26 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $stmt->execute(array($colorScheme, $fontSize, $userId));
     $_SESSION['color_scheme'] = $colorScheme;
     $_SESSION['font_size'] = $fontSize;
+
+    $accentColor = isset($_POST['accent_color']) ? $_POST['accent_color'] : '#003399';
+    $backgroundColor = isset($_POST['background_color']) ? $_POST['background_color'] : '#e5e5e5';
+    $textColor = isset($_POST['text_color']) ? $_POST['text_color'] : '#000000';
+
+    // basic validation for hex colors
+    foreach (['accentColor' => &$accentColor, 'backgroundColor' => &$backgroundColor, 'textColor' => &$textColor] as $var => &$color) {
+        if (!preg_match('/^#[0-9a-fA-F]{6}$/', $color)) {
+            $color = $var === 'accentColor' ? '#003399' : ($var === 'backgroundColor' ? '#e5e5e5' : '#000000');
+        }
+    }
+    saveUserColors($userId, $accentColor, $backgroundColor, $textColor);
+    $_SESSION['accent_color'] = $accentColor;
+    $_SESSION['background_color'] = $backgroundColor;
+    $_SESSION['text_color'] = $textColor;
 }
 
 $currentScheme = fetchColorScheme($userId);
 $currentFont = fetchFontSize($userId);
+$currentColors = fetchUserColors($userId);
 
 ?>
 <?php require("header.php"); ?>
@@ -146,6 +162,15 @@ $currentFont = fetchFontSize($userId);
           <option value="normal" <?= $currentFont === 'normal' ? 'selected' : '' ?>>Normal</option>
           <option value="large" <?= $currentFont === 'large' ? 'selected' : '' ?>>Large</option>
         </select>
+        <br>
+        <label for="accent_color">Accent Color:</label>
+        <input type="color" id="accent_color" name="accent_color" value="<?= htmlspecialchars($currentColors['accent_color'], ENT_QUOTES) ?>">
+        <br>
+        <label for="background_color">Background Color:</label>
+        <input type="color" id="background_color" name="background_color" value="<?= htmlspecialchars($currentColors['background_color'], ENT_QUOTES) ?>">
+        <br>
+        <label for="text_color">Text Color:</label>
+        <input type="color" id="text_color" name="text_color" value="<?= htmlspecialchars($currentColors['text_color'], ENT_QUOTES) ?>">
       </div>
     </div>
 

--- a/schema.sql
+++ b/schema.sql
@@ -423,6 +423,7 @@ CREATE TABLE IF NOT EXISTS `forum_user_settings` (
   `background_image_url` varchar(255) DEFAULT NULL,
   `background_color` varchar(7) DEFAULT NULL,
   `text_color` varchar(7) DEFAULT NULL,
+  `accent_color` varchar(7) DEFAULT NULL,
   PRIMARY KEY (`user_id`),
   FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
## Summary
- Add accent, background and text color pickers to account settings
- Store custom colors in `forum_user_settings` and expose helpers to fetch/save them
- Inject user color preferences as CSS variables in the global header

## Testing
- `php -l core/forum.php`
- `php -l core/site/user.php`
- `php -l public/header.php`
- `php -l public/settings.php`


------
https://chatgpt.com/codex/tasks/task_e_689c13403aa083218b37d064226e9027