### PR TITLE
feat: allow editing front page content

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ system.
 - [x] Layout sharing feature
 - [x] Private Messaging
 - [x] Report System
+- [x] Editable static pages (homepage, about)
 - [x] Session Management
 - [x] User Browser
 - [x] User Search

--- a/admin/navbar.php
+++ b/admin/navbar.php
@@ -45,6 +45,7 @@
 
       $navItems = array(
         'General' => 'index.php',
+        'Pages' => 'pages.php',
         'Users' => 'users.php',
         'Search' => 'search.php',
         'Reports' => 'reports.php',

--- a/admin/pages.php
+++ b/admin/pages.php
@@ -1,0 +1,62 @@
+<?php
+require("../core/conn.php");
+require_once("../core/settings.php");
+
+// Page functions
+require("../core/site/admin/pages.php");
+
+login_check();
+
+$pages = get_pages_config();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['submit'])) {
+    $home = isset($_POST['pages']['home_welcome']) ? validateContentHTML($_POST['pages']['home_welcome']) : '';
+    $about = isset($_POST['pages']['about']) ? validateContentHTML($_POST['pages']['about']) : '';
+
+    if (update_page_config(array('home_welcome' => $home, 'about' => $about))) {
+        header("Location: pages.php?status=success");
+        exit;
+    } else {
+        $error = "Failed to update pages.";
+    }
+    $pages = get_pages_config();
+}
+
+require("header.php");
+?>
+
+<div class="simple-container">
+    <div class="row edit-profile">
+        <div class="col w-20 left">
+            <!-- SIDEBAR CONTENT -->
+        </div>
+        <div class="col right">
+            <h1>Page Content</h1>
+            <p>Edit homepage and about page content</p>
+            <form method="post" class="ctrl-enter-submit">
+    <?= csrf_token_input(); ?>
+                <button type="submit" name="submit">Save All</button>
+                <br>
+                <label for="pages_home_welcome">
+                    <h3>Homepage Message:</h3>
+                </label>
+                <textarea id="pages_home_welcome" class="status_input" name="pages[home_welcome]" rows="3"><?= htmlspecialchars($pages['home_welcome']) ?></textarea>
+                <label for="pages_about">
+                    <h3>About Page Content:</h3>
+                </label>
+                <textarea id="pages_about" class="status_input" name="pages[about]" rows="6"><?= htmlspecialchars($pages['about']) ?></textarea>
+                <p></p>
+                <button type="submit" name="submit">Save All</button>
+            </form>
+            <?php
+            if (isset($_GET['status']) && $_GET['status'] === 'success') {
+                echo "<p style='color: green;'>Pages updated successfully.</p>";
+            } elseif (isset($error)) {
+                echo "<p style='color: red;'>$error</p>";
+            }
+            ?>
+        </div>
+    </div>
+</div>
+
+<?php require("../public/footer.php"); ?>

--- a/core/page_config.php
+++ b/core/page_config.php
@@ -1,0 +1,5 @@
+<?php
+return array(
+    'home_welcome' => 'Did you know...? AnySpace is OpenSource!',
+    'about' => 'Anyspace is an open source social media platform in the style of Myspace between 2005-2007.'
+);

--- a/core/site/admin/pages.php
+++ b/core/site/admin/pages.php
@@ -1,0 +1,24 @@
+<?php
+function get_pages_config() {
+    $config_file = __DIR__ . '/../../page_config.php';
+    if (file_exists($config_file)) {
+        return include($config_file);
+    }
+    return array(
+        'home_welcome' => '',
+        'about' => ''
+    );
+}
+
+function update_page_config($new_config) {
+    $config_file = __DIR__ . '/../../page_config.php';
+    $config = get_pages_config();
+    foreach ($new_config as $key => $value) {
+        if (array_key_exists($key, $config)) {
+            $config[$key] = $value;
+        }
+    }
+    $config_content = "<?php\nreturn " . var_export($config, true) . ";\n";
+    return file_put_contents($config_file, $config_content) !== false;
+}
+?>

--- a/core/site/page.php
+++ b/core/site/page.php
@@ -1,0 +1,12 @@
+<?php
+function get_page_content($page) {
+    $config_file = __DIR__ . '/../page_config.php';
+    if (file_exists($config_file)) {
+        $config = include($config_file);
+        if (isset($config[$page])) {
+            return $config[$page];
+        }
+    }
+    return '';
+}
+?>

--- a/public/about.php
+++ b/public/about.php
@@ -1,6 +1,7 @@
 <?php
 require("../core/conn.php");
 require_once("../core/settings.php");
+require("../core/site/page.php");
 
 ?>
 <?php require("header.php"); ?>
@@ -8,7 +9,7 @@ require_once("../core/settings.php");
 <div class="simple-container">
     <h1>About <?= SITE_NAME ?></h1>
     <br>
-    Anyspace is an open source social media platform in the style of Myspace between 2005-2007.
+    <?= get_page_content('about'); ?>
 </div>
 
 <?php require("footer.php"); ?>

--- a/public/index.php
+++ b/public/index.php
@@ -7,6 +7,7 @@ if (!file_exists("../core/config.php")) {
 require("../core/conn.php");
 require("../core/settings.php");
 require("../core/site/user.php");
+require("../core/site/page.php");
 require("../lib/password.php");
 
 if (isset($_SESSION['user'])) {
@@ -143,7 +144,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['action'])) {
                 <!-- MOTD -->
                 <div class="col right">
                     <div class="welcome">
-                        <p>Did you know...? AnySpace is OpenSource!</p>
+                        <p><?= get_page_content('home_welcome'); ?></p>
                     </div>
                     <div class="box">
                         <!-- Login/Signup Form -->

--- a/tests/forum_mod_dashboard.php
+++ b/tests/forum_mod_dashboard.php
@@ -15,6 +15,7 @@ $conn->exec('CREATE TABLE forum_posts (id INTEGER PRIMARY KEY AUTOINCREMENT, top
 $conn->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, rank INTEGER, username TEXT, email TEXT, password TEXT, banned_until TEXT)');
 $conn->exec('CREATE TABLE mod_log (id INTEGER PRIMARY KEY AUTOINCREMENT, moderator_id INTEGER, action TEXT, target_type TEXT, target_id INTEGER, timestamp TEXT DEFAULT CURRENT_TIMESTAMP)');
 $conn->exec('CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, sender_id INTEGER, receiver_id INTEGER, subject TEXT, body TEXT, sent_at TEXT, read_at TEXT DEFAULT NULL, sender_deleted INTEGER DEFAULT 0, receiver_deleted INTEGER DEFAULT 0)');
+$conn->exec('CREATE TABLE forum_user_settings (user_id INTEGER PRIMARY KEY, accent_color TEXT, background_color TEXT, text_color TEXT)');
 
 global $conn;
 


### PR DESCRIPTION
## Summary
- add page configuration file and helpers
- allow admins to edit homepage message and about page from new Pages screen
- load dynamic page content on frontend and update documentation
- include forum_user_settings table in moderator dashboard test

## Testing
- `php -l admin/pages.php`
- `php -l core/site/admin/pages.php`
- `php -l core/site/page.php`
- `php -l core/page_config.php`
- `php -l public/index.php`
- `php -l public/about.php`
- `php -l tests/forum_mod_dashboard.php`
- `for t in tests/*.php; do php "$t"; done`


------
https://chatgpt.com/codex/tasks/task_e_689c15d003908321920b57de52988a6d