### PR TITLE
Add RSS feed for blog entries

### DIFF
--- a/public/blog/blog-header.php
+++ b/public/blog/blog-header.php
@@ -8,6 +8,7 @@ header("Content-Security-Policy: default-src 'self'; img-src 'self' data:; style
     <title><?= SITE_NAME ?> | Blog</title>
     <link rel="stylesheet" href="/static/css/normalize.min.css">
     <link rel="stylesheet" href="/static/css/style.min.css">
+    <?= $rssLinkTag ?? '<link rel="alternate" type="application/rss+xml" title="Blog RSS" href="/blog/rss.php">' ?>
 </head>
 
 <body>

--- a/public/blog/index.php
+++ b/public/blog/index.php
@@ -5,6 +5,7 @@ require_once("../../core/site/user.php");
 require_once("../../core/site/blog.php");
 require_once("../../core/site/comment.php");
 
+$rssLinkTag = '<link rel="alternate" type="application/rss+xml" title="Blog RSS" href="/blog/rss.php">';
 $blogEntries = fetchAllBlogEntries();
 $highlightedEntry = 11;
 
@@ -73,7 +74,7 @@ $highlightedEntry = 11;
         </div>
       </div>
       <hr>
-      <h3>Latest Blog Entries</h3>
+      <h3>Latest Blog Entries <a href="/blog/rss.php">RSS</a></h3>
       <div class="blog-entries">
         <?php foreach ($blogEntries as $entry): ?>
           <?php $countTotalComments = count(fetchBlogComments($entry['id'])); ?>

--- a/public/blog/rss.php
+++ b/public/blog/rss.php
@@ -1,0 +1,27 @@
+<?php
+require __DIR__ . '/../../core/conn.php';
+require __DIR__ . '/../../core/settings.php';
+require __DIR__ . '/../../core/site/blog.php';
+
+header('Content-Type: application/rss+xml; charset=UTF-8');
+
+$entries = fetchAllBlogEntries(20);
+
+echo '<?xml version="1.0" encoding="UTF-8"?>';
+?>
+<rss version="2.0">
+  <channel>
+    <title><?= SITE_NAME ?> Blog</title>
+    <link>https://<?= DOMAIN_NAME ?>/blog/</link>
+    <description>Latest blog entries from <?= SITE_NAME ?></description>
+<?php foreach ($entries as $entry): ?>
+    <item>
+      <title><?= htmlspecialchars($entry['title']) ?></title>
+      <link>https://<?= DOMAIN_NAME ?>/blog/entry.php?id=<?= $entry['id'] ?></link>
+      <pubDate><?= date(DATE_RSS, strtotime($entry['date'])) ?></pubDate>
+      <guid>https://<?= DOMAIN_NAME ?>/blog/entry.php?id=<?= $entry['id'] ?></guid>
+    </item>
+<?php endforeach; ?>
+  </channel>
+</rss>
+

--- a/tests/blog_rss.php
+++ b/tests/blog_rss.php
@@ -1,0 +1,34 @@
+<?php
+// Integration test for blog RSS feed endpoint
+
+// Setup SQLite database and configure connection
+$dbFile = __DIR__ . '/blog_rss_test.db';
+@unlink($dbFile);
+$dsn = 'sqlite:' . $dbFile;
+putenv('DB_DSN=' . $dsn);
+
+// Establish connection and seed data
+$conn = new PDO($dsn);
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$conn->exec('CREATE TABLE blogs (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, text TEXT, author INTEGER, category INTEGER, date TEXT)');
+$conn->exec("INSERT INTO blogs (title, text, author, category, date) VALUES ('Test entry', 'Content', 1, 1, datetime('now'))");
+
+// Settings variables expected by settings.php
+$siteName = 'AnySpace';
+$domainName = 'example.com';
+$adminUser = 1;
+
+ob_start();
+require __DIR__ . '/../public/blog/rss.php';
+$output = ob_get_clean();
+
+if (strpos($output, '<rss') !== false && strpos($output, '<channel>') !== false) {
+    echo "RSS feed output OK\n";
+} else {
+    echo "RSS feed output failed\n";
+    exit(1);
+}
+
+// Cleanup temporary database
+unlink($dbFile);
+


### PR DESCRIPTION
## Summary
- add `/blog/rss.php` to serve latest blog entries as RSS
- expose RSS link in blog pages and list view
- test RSS endpoint outputs <rss> channel structure

## Testing
- `php tests/blog_rss.php`


------
https://chatgpt.com/codex/tasks/task_e_689c1cfdea1883218d007e1c3e98b17a