### PR TITLE
Harden group creation and membership workflows

### DIFF
--- a/public/groups/groups.php
+++ b/public/groups/groups.php
@@ -49,7 +49,12 @@ if (!isset($_SESSION['user'])) {
                     echo "<td><a href='../profile.php?id=" . getID($row['author'], $conn) . "'>" . htmlspecialchars($row['author']) . "</a></td>";
                     echo "<td>" . $row['member_count'] . "</td>";
                     echo "<td>" . date('M j, Y', strtotime($row['date'])) . "</td>";
-                    echo "<td><a href='joingroup.php?id=" . $row['id'] . "'>Join</a> | <a href='viewgroup.php?id=" . $row['id'] . "'>View</a></td>";
+                    echo "<td>";
+                    echo "<form method='post' action='joingroup.php' style='display:inline;'>";
+                    echo csrf_token_input();
+                    echo "<input type='hidden' name='group_id' value='" . $row['id'] . "'>";
+                    echo "<button type='submit'>Join</button>";
+                    echo "</form> | <a href='viewgroup.php?id=" . $row['id'] . "'>View</a></td>";
                     echo "</tr>";
                 }
                 

--- a/public/groups/joingroup.php
+++ b/public/groups/joingroup.php
@@ -3,44 +3,33 @@ require("../../core/conn.php");
 require_once("../../core/settings.php");
 require_once("../../core/site/user.php");
 
-if (!isset($_SESSION['user'])) {
-    header("Location: ../login.php");
-    exit;
-}
+login_check();
 
-if((int)$_GET['id']) {
-    $group_id = (int)$_GET['id'];
-    
-    // Get group name for display
-    $stmt = $conn->prepare("SELECT * FROM `groups` WHERE id = ?");
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['group_id'])) {
+    $group_id = (int)$_POST['group_id'];
+
+    $stmt = $conn->prepare("SELECT name FROM `groups` WHERE id = ?");
     $stmt->execute([$group_id]);
-    $result = $stmt->fetch(PDO::FETCH_ASSOC);
-    
-    if ($result) {
-        $groupname = $result['name'];
-        
-        // Check if user is already a member
-        $stmt = $conn->prepare("SELECT * FROM `group_memberships` WHERE group_id = ? AND username = ?");
+    $group = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($group) {
+        $stmt = $conn->prepare("SELECT 1 FROM `group_memberships` WHERE group_id = ? AND username = ?");
         $stmt->execute([$group_id, $_SESSION['user']]);
-        $membership_result = $stmt->fetch(PDO::FETCH_ASSOC);
-        
-        if (!$membership_result) {
-            // Add user to group
+        if (!$stmt->fetch()) {
             $stmt = $conn->prepare("INSERT INTO `group_memberships` (group_id, username) VALUES (?, ?)");
             $stmt->execute([$group_id, $_SESSION['user']]);
-            
-            // Also update the currentgroup field for backwards compatibility
+
             $stmt = $conn->prepare("UPDATE users SET currentgroup = ? WHERE username = ?");
-            $stmt->execute([$groupname, $_SESSION['user']]);
-            
+            $stmt->execute([$group['name'], $_SESSION['user']]);
+
             header("Location: viewgroup.php?id=" . $group_id . "&msg=joined");
-        } else {
-            header("Location: viewgroup.php?id=" . $group_id . "&msg=already_member");
+            exit;
         }
-    } else {
-        header("Location: groups.php?msg=group_not_found");
+        header("Location: viewgroup.php?id=" . $group_id . "&msg=already_member");
+        exit;
     }
-} else {
-    header("Location: groups.php");
 }
+
+header("Location: groups.php?msg=group_not_found");
+exit;
 ?>

--- a/public/groups/newgroup.php
+++ b/public/groups/newgroup.php
@@ -1,7 +1,44 @@
 <?php
-    require("../../core/conn.php");
-    require_once("../../core/settings.php");
-    require_once("../../core/site/user.php");
+require("../../core/conn.php");
+require_once("../../core/settings.php");
+require_once("../../core/site/user.php");
+
+login_check();
+
+$error = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['groupname'] ?? '');
+    $desc = trim($_POST['desc'] ?? '');
+
+    if ($name === '' || $desc === '') {
+        $error = 'All fields are required.';
+    } elseif (mb_strlen($name) > 100 || mb_strlen($desc) > 500) {
+        $error = 'Group name or description too long.';
+    } else {
+        $name = strip_tags($name);
+        $desc = validateContentHTML($desc);
+
+        $stmt = $conn->prepare("SELECT COUNT(*) FROM `groups` WHERE name = ?");
+        $stmt->execute([$name]);
+        if ($stmt->fetchColumn() > 0) {
+            $error = 'A group with that name already exists.';
+        } else {
+            $stmt = $conn->prepare("INSERT INTO `groups` (name, description, author, date) VALUES (?, ?, ?, CURRENT_TIMESTAMP)");
+            $stmt->execute([$name, $desc, $_SESSION['user']]);
+            $group_id = $conn->lastInsertId();
+
+            $stmt = $conn->prepare("INSERT INTO `group_memberships` (group_id, username, role) VALUES (?, ?, 'owner')");
+            $stmt->execute([$group_id, $_SESSION['user']]);
+
+            $stmt = $conn->prepare("UPDATE users SET currentgroup = ? WHERE username = ?");
+            $stmt->execute([$name, $_SESSION['user']]);
+
+            header("Location: viewgroup.php?id=" . $group_id);
+            exit;
+        }
+    }
+}
 ?>
 <!DOCTYPE html>
 <html>
@@ -10,35 +47,14 @@
         <link rel="stylesheet" href="../static/css/base.css">
     </head>
     <body>
-        <?php
-            require("../../core/components/navbar.php");
-        ?>
+        <?php require("../../core/components/navbar.php"); ?>
         <div class="container">
-            <?php
-                if(@$_POST) {
-                    $text = str_replace(PHP_EOL, "<br>", $_POST['desc']);
-                    $name = htmlspecialchars($_POST['groupname']);
-                    
-                    $stmt = $conn->prepare("INSERT INTO `groups` (name, description, author, date) VALUES (?, ?, ?, datetime('now'))");
-                    $stmt->execute([$name, $text, $_SESSION['user']]);
-                    $group_id = $conn->lastInsertId();
-                    
-                    // Add creator as first member
-                    $stmt = $conn->prepare("INSERT INTO `group_memberships` (group_id, username, role) VALUES (?, ?, 'owner')");
-                    $stmt->execute([$group_id, $_SESSION['user']]);
-                    
-                    $stmt = $conn->prepare("UPDATE users SET currentgroup = ? WHERE username = ?");
-                    $stmt->execute([$name, $_SESSION['user']]);
-                    
-                    header("Location: viewgroup.php?id=" . $group_id);
-                    exit;             
-                }
-            ?>
-            <form method="post" enctype="multipart/form-data">
-    <?= csrf_token_input(); ?>
-                <input required placeholder="Name" size="90" type="text" name="groupname"><br>
-				<textarea required rows="10" cols="68" placeholder="Description" name="desc"></textarea><br>
-				<input name="submit" type="submit" value="Create"> <small>max limit: 500 characters</small>
+            <?php if ($error) { echo "<div class='error'>" . htmlspecialchars($error) . "</div>"; } ?>
+            <form method="post">
+                <?= csrf_token_input(); ?>
+                <input required placeholder="Name" size="90" type="text" name="groupname" maxlength="100"><br>
+                <textarea required rows="10" cols="68" placeholder="Description" name="desc" maxlength="500"></textarea><br>
+                <input name="submit" type="submit" value="Create"> <small>max limit: 500 characters</small>
             </form>
         </div>
     </body>

--- a/public/groups/viewgroup.php
+++ b/public/groups/viewgroup.php
@@ -1,105 +1,110 @@
 <?php
-    require("../../core/conn.php");
-    require_once("../../core/settings.php");
-    require_once("../../core/site/user.php");
+require("../../core/conn.php");
+require_once("../../core/settings.php");
+require_once("../../core/site/user.php");
+
+// Fetch group information
+$stmt = $conn->prepare("SELECT * FROM `groups` WHERE id = ?");
+$stmt->execute([(int)($_GET['id'] ?? 0)]);
+$group = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$group) {
+    header("Location: groups.php?msg=group_not_found");
+    exit;
+}
+$name   = $group['name'];
+$desc   = $group['description'];
+$author = $group['author'];
+$date   = $group['date'];
+
+// Determine membership
+$membership = null;
+if (isset($_SESSION['user'])) {
+    $stmt = $conn->prepare("SELECT * FROM `group_memberships` WHERE group_id = ? AND username = ?");
+    $stmt->execute([(int)$group['id'], $_SESSION['user']]);
+    $membership = $stmt->fetch(PDO::FETCH_ASSOC);
+}
+
+// Handle comment submission
+if (isset($_SESSION['user']) && isset($_POST['comment'])) {
+    $stmt = $conn->prepare("INSERT INTO `groupcomments` (toid, author, text, date) VALUES (?, ?, ?, CURRENT_TIMESTAMP)");
+    $unprocessedText = replaceBBcodes($_POST['comment']);
+    $text = validateContentHTML($unprocessedText);
+    $stmt->execute([(int)$group['id'], $_SESSION['user'], $text]);
+}
+
+// Handle event creation for members
+if (isset($_SESSION['user']) && $membership && isset($_POST['create_event'])) {
+    $title = trim($_POST['event_title'] ?? '');
+    $description = trim($_POST['event_description'] ?? '');
+    $eventDate = $_POST['event_date'] ?? '';
+    if ($title !== '' && $description !== '' && $eventDate !== '') {
+        $title = strip_tags($title);
+        $description = validateContentHTML($description);
+        $stmt = $conn->prepare("INSERT INTO `group_events` (group_id, title, description, event_date, created_by) VALUES (?, ?, ?, ?, ?)");
+        $stmt->execute([(int)$group['id'], $title, $description, $eventDate, $_SESSION['user']]);
+    }
+}
 ?>
 <!DOCTYPE html>
 <html>
     <head>
         <link rel="stylesheet" href="../static/css/header.css">
         <link rel="stylesheet" href="../static/css/base.css">
-        <?php
-            $stmt = $conn->prepare("SELECT * FROM `groups` WHERE id = ?");
-            $stmt->execute([(int)$_GET['id']]);
-            $result = $stmt->fetch(PDO::FETCH_ASSOC);
-            
-            if ($result) {
-                $name = $result['name'];
-                $desc = $result['description'];
-                $author = $result['author'];
-                $date = $result['date'];
-            } else {
-                header("Location: groups.php?msg=group_not_found");
-                exit;
-            }
-
-            if(@$_POST["comment"]) {
-                $stmt = $conn->prepare("INSERT INTO `groupcomments` (toid, author, text, date) VALUES (?, ?, ?, datetime('now'))");
-                
-                $unprocessedText = replaceBBcodes($_POST['comment']);
-                $text = str_replace(PHP_EOL, "<br>", $unprocessedText);
-                $stmt->execute([(int)$_GET['id'], $_SESSION['user'], $text]);
-            }
-        ?>
     </head>
     <body>
-        <?php
-            require("../../core/components/navbar.php");
-        ?>
+        <?php require("../../core/components/navbar.php"); ?>
         <div class="container">
-            <h1><?php echo $name; ?></h1>
+            <h1><?= htmlspecialchars($name); ?></h1>
             <?php
-                echo "Owner: <a href='../profile.php?id=" . getID($author, $conn) . "'>" . $author . "</a>";
-                
-                // Show join/leave button
+                echo "Owner: <a href='../profile.php?id=" . getID($author, $conn) . "'>" . htmlspecialchars($author) . "</a>";
                 if (isset($_SESSION['user'])) {
-                    $stmt = $conn->prepare("SELECT * FROM `group_memberships` WHERE group_id = ? AND username = ?");
-                    $stmt->execute([(int)$_GET['id'], $_SESSION['user']]);
-                    $membership_result = $stmt->fetch(PDO::FETCH_ASSOC);
-                    
-                    if (!$membership_result) {
-                        echo " | <a href='joingroup.php?id=" . $_GET['id'] . "' style='background: #007bff; color: white; padding: 5px 10px; text-decoration: none; border-radius: 3px;'>Join Group</a>";
-                    } else {
-                        echo " | <span style='background: #28a745; color: white; padding: 5px 10px; border-radius: 3px;'>Member</span>";
-                    }
+                    if (!$membership) { ?>
+                        | <form method="post" action="joingroup.php" style="display:inline;">
+                            <?= csrf_token_input(); ?>
+                            <input type="hidden" name="group_id" value="<?= (int)$group['id']; ?>">
+                            <button type="submit" style="background: #007bff; color: white; padding: 5px 10px; border: none; border-radius: 3px;">Join Group</button>
+                        </form>
+                    <?php } else { ?>
+                        | <span style="background: #28a745; color: white; padding: 5px 10px; border-radius: 3px;">Member</span>
+                    <?php }
                 }
-                
-                // Show messages
                 if (isset($_GET['msg'])) {
-                    if ($_GET['msg'] == 'joined') {
+                    if ($_GET['msg'] === 'joined') {
                         echo "<div class='success' style='margin: 10px 0;'>Successfully joined the group!</div>";
-                    } elseif ($_GET['msg'] == 'already_member') {
+                    } elseif ($_GET['msg'] === 'already_member') {
                         echo "<div class='info' style='margin: 10px 0;'>You are already a member of this group.</div>";
                     }
                 }
             ?>
-            <pre><?php echo $desc;?></pre>
-            
+            <pre><?= $desc; ?></pre>
+
             <!-- Events Section -->
             <div class="info">
                 <center>Upcoming Events</center>
             </div>
-            <?php
-                // Handle event creation
-                if(@$_POST["create_event"]) {
-                    $stmt = $conn->prepare("INSERT INTO `group_events` (group_id, title, description, event_date, created_by) VALUES (?, ?, ?, ?, ?)");
-                    $stmt->execute([(int)$_GET['id'], $_POST['event_title'], $_POST['event_description'], $_POST['event_date'], $_SESSION['user']]);
-                }
-                
-                // Show event creation form (only for group members or owner)
-                echo "<details>";
-                echo "<summary>Create New Event</summary>";
-                echo "<form method='post' enctype='multipart/form-data'>";
-                echo csrf_token_input();
-                echo "<input required placeholder='Event Title' size='60' type='text' name='event_title'><br>";
-                echo "<textarea required rows='3' cols='60' placeholder='Event Description' name='event_description'></textarea><br>";
-                echo "<input required type='datetime-local' name='event_date'><br>";
-                echo "<input name='create_event' type='submit' value='Create Event'>";
-                echo "</form>";
-                echo "</details>";
-                echo "<br>";
-                
-                // Display events
+            <?php if (isset($_SESSION['user']) && $membership) { ?>
+                <details>
+                    <summary>Create New Event</summary>
+                    <form method="post">
+                        <?= csrf_token_input(); ?>
+                        <input required placeholder="Event Title" size="60" type="text" name="event_title" maxlength="255"><br>
+                        <textarea required rows="3" cols="60" placeholder="Event Description" name="event_description"></textarea><br>
+                        <input required type="datetime-local" name="event_date"><br>
+                        <input name="create_event" type="submit" value="Create Event">
+                    </form>
+                </details>
+                <br>
+            <?php }
                 $stmt = $conn->prepare("SELECT * FROM `group_events` WHERE group_id = ? ORDER BY event_date ASC");
-                $stmt->execute([(int)$_GET['id']]);
+                $stmt->execute([(int)$group['id']]);
                 $events = $stmt->fetchAll(PDO::FETCH_ASSOC);
-                
-                if (count($events) > 0) {
-                    foreach($events as $event) {
+
+                if ($events) {
+                    foreach ($events as $event) {
                         $event_date = new DateTime($event['event_date']);
                         $now = new DateTime();
                         $is_past = $event_date < $now;
-                        
+
                         echo "<div class='event-item' style='border: 1px solid #ccc; margin: 10px 0; padding: 10px; " . ($is_past ? "opacity: 0.6;" : "") . "'>";
                         echo "<h4>" . htmlspecialchars($event['title']) . " " . ($is_past ? "(Past)" : "") . "</h4>";
                         echo "<p><strong>Date:</strong> " . $event_date->format('M j, Y g:i A') . "</p>";
@@ -111,20 +116,20 @@
                     echo "<p>No events scheduled. Create one above!</p>";
                 }
             ?>
-            
+
             <!-- Members Section -->
             <div class="info" style="margin-top: 20px;">
                 <center>Group Members</center>
             </div>
             <?php
                 $stmt = $conn->prepare("SELECT username, joined_at, role FROM `group_memberships` WHERE group_id = ? ORDER BY joined_at ASC");
-                $stmt->execute([(int)$_GET['id']]);
+                $stmt->execute([(int)$group['id']]);
                 $members = $stmt->fetchAll(PDO::FETCH_ASSOC);
-                
-                if (count($members) > 0) {
+
+                if ($members) {
                     echo "<div style='margin: 10px 0;'>";
                     echo "<strong>Members (" . count($members) . "):</strong><br>";
-                    foreach($members as $member) {
+                    foreach ($members as $member) {
                         $user_id = getID($member['username'], $conn);
                         $pfp = getPFP($member['username'], $conn);
                         echo "<div style='display: inline-block; margin: 10px; text-align: center; width: 80px;'>";
@@ -139,26 +144,28 @@
                     echo "<p>No members yet. Be the first to join!</p>";
                 }
             ?>
-            
+
             <div class="info" style="margin-top: 20px;">
                 <center>Comments</center>
             </div>
-            <form method="post" enctype="multipart/form-data">
-    <?= csrf_token_input(); ?>
-				<textarea required rows="5" cols="80" placeholder="Comment" name="comment"></textarea><br>
-				<input name="submit" type="submit" value="Post"> <small>max limit: 500 characters</small>
+            <?php if (isset($_SESSION['user'])) { ?>
+            <form method="post">
+                <?= csrf_token_input(); ?>
+                <textarea required rows="5" cols="80" placeholder="Comment" name="comment" maxlength="500"></textarea><br>
+                <input name="submit" type="submit" value="Post"> <small>max limit: 500 characters</small>
             </form>
+            <?php } else { echo "<p>Login to comment.</p>"; } ?>
             <br><hr>
             <?php
                 $stmt = $conn->prepare("SELECT * FROM `groupcomments` WHERE toid = ? ORDER BY date DESC");
-                $stmt->execute([(int)$_GET['id']]);
+                $stmt->execute([(int)$group['id']]);
                 $comments = $stmt->fetchAll(PDO::FETCH_ASSOC);
-                
-                foreach($comments as $row) {
+
+                foreach ($comments as $row) {
                     echo "<div class='commentRight'>";
-                    echo "  <small>" . $row['date'] . "</small><br>" . $row['text'];
-                    echo "  <a style='float: right;' href='../profile.php?id=" . getID($row['author'], $conn) . "'>" . $row['author'] . "</a> <br>";
-                    echo "  <img class='commentPictures' style='float: right;' width='80px;'src='../media/pfp/" . getPFP($row['author'], $conn) . "'><br><br><br><br><br>";
+                    echo "  <small>" . htmlspecialchars($row['date']) . "</small><br>" . $row['text'];
+                    echo "  <a style='float: right;' href='../profile.php?id=" . getID($row['author'], $conn) . "'>" . htmlspecialchars($row['author']) . "</a> <br>";
+                    echo "  <img class='commentPictures' style='float: right;' width='80px;' src='../media/pfp/" . htmlspecialchars(getPFP($row['author'], $conn)) . "'><br><br><br><br><br>";
                     echo "</div>";
                 }
             ?>


### PR DESCRIPTION
## Summary
- enforce authentication and input validation when creating groups
- switch group joins to CSRF-protected POST requests and restrict event creation to members
- sanitize group comments and events and display membership data securely

## Testing
- `php tests/groups_system.php`
- `for t in tests/*.php; do echo "Running $t"; php $t >/tmp/out; tail -n 2 /tmp/out; done`


------
https://chatgpt.com/codex/tasks/task_e_689cff514ea8832185834da6c1fcabd2